### PR TITLE
Signs: add sign "Straßenbahn frei"

### DIFF
--- a/packages/traffic-sign-converter/src/data-definitions/DE/data/exceptions__thing_allowed.ts
+++ b/packages/traffic-sign-converter/src/data-definitions/DE/data/exceptions__thing_allowed.ts
@@ -235,6 +235,27 @@ export const _exceptions__thing_allowed: SignType[] = [
     },
   },
   {
+    osmValuePart: '1024-16',
+    signId: '1024-16',
+    name: 'Zusatzzeichen 1024-16',
+    descriptiveName: 'Straßenbahn frei',
+    description: null,
+    kind: 'exception_modifier',
+    tagRecommendations: {
+      highwayValues: [],
+      modifierValue: 'tram',
+    },
+    comments: [],
+    catalogue: {
+      signCategory: 'exception_modifier',
+    },
+    image: {
+      sourceUrl:
+        'https://commons.wikimedia.org/wiki/File:Zusatzzeichen_1024-16_-_Straßenbahn_frei,_StVO_1992.svg',
+      licence: 'Public Domain',
+    },
+  },
+  {
     osmValuePart: '1024-17',
     signId: '1024-17',
     name: 'Zusatzzeichen 1024-17',

--- a/packages/traffic-sign-converter/src/signsToTags/utils/sortTags.ts
+++ b/packages/traffic-sign-converter/src/signsToTags/utils/sortTags.ts
@@ -48,6 +48,7 @@ const sortedAccessKeys = [
   'taxi',
   'minibus',
   'share_taxi',
+  'tram',
   'hov',
   'carpool',
   'car_sharing',


### PR DESCRIPTION
I recently stumbled over a "Straßenbahn frei" sign and thought this would be a nice addition to the traffic sign tool.

This PR is just a guess how this would be implemented. I basically copied another 1024-ish sign and adapted it with tram info. Not sure whether this is how it is supposed to be done, but I got it to build locally (after reverting b33a5d6a) and the dev application did show a new button for "Straßenbahn frei". However, the actual image sign did not appear to load, unfortunately.

So, all in all, definitely a draft, @tordans feel free to reject/change/... – I simply figured playing with the code myself would be easier than writing an issue first.
