### PR TITLE
Docs: Plan for converter JSON sign data exports

### DIFF
--- a/docs/superpowers/plans/2026-05-27-converter-json-sign-data-exports.md
+++ b/docs/superpowers/plans/2026-05-27-converter-json-sign-data-exports.md
@@ -4,9 +4,9 @@
 
 **Goal:** Ship plain JSON files alongside the compiled JS in `@osm-traffic-signs/converter` so consumers can load traffic sign definitions without executing TypeScript or bundling the package’s modules.
 
-**Architecture:** Keep the source of truth as today’s TypeScript modules under `src/data-definitions/`. After `tsc` emits `dist/`, run a small Node ESM script that dynamically imports the built `countryDefinitions` (and `generalRedirects` for redirect metadata used at runtime) from `dist/`, then writes UTF-8 JSON under `dist/sign-data/`. Declare stable `package.json` `exports` subpaths for those JSON files so resolution works under Node 16+ and bundlers. Document consumption in the converter README.
+**Architecture:** Keep the source of truth as today’s TypeScript modules under `src/data-definitions/`. After `tsc` emits `dist/`, run a small Node ESM script that dynamically imports the built `countryDefinitions` (and `generalRedirects` for redirect metadata used at runtime) from `dist/`, then writes UTF-8 JSON under `dist/sign-data/`. Declare stable `package.json` `exports` subpaths for those JSON files so resolution works under Node 16+ and bundlers. Copy the same JSON tree into the TanStack app’s static output (`public/sign-data/` → Vite `dist/sign-data/`) so Netlify deploy previews and GitHub Pages can serve them over HTTPS for manual smoke tests. Document consumption in the converter README; surface the package and JSON URLs in the app footer.
 
-**Tech Stack:** Node 22+, `pnpm`, existing `tsc` + `copyfiles` build, `@arethetypeswrong/cli` (`check-exports`), `vitest`.
+**Tech Stack:** Node 22+, `pnpm`, `turbo`, existing `tsc` + `copyfiles` build, Vite, TanStack Router, Paraglide i18n, `@arethetypeswrong/cli` (`check-exports`), `vitest`, `bun run release-cli.ts` for manual npm releases, Netlify deploy previews (`netlify.toml`).
 
 ---
 
@@ -19,6 +19,11 @@
 | `packages/traffic-sign-converter/README.md` | Document JSON subpaths and example `import` / `readFile` usage |
 | `packages/traffic-sign-converter/CHANGELOG.md` | Unreleased bullet for JSON exports |
 | `packages/traffic-sign-converter/src/...` | **No change** to sign data TS (single source of truth unchanged) unless you later dedupe helpers |
+| `apps/traffic-sign-tool/package.json` | Add `build:copy-sign-data` (or similar) before Vite; depends on converter `^build` via turbo |
+| `apps/traffic-sign-tool/public/sign-data/.gitkeep` or `.gitignore` | Generated JSON not committed; ensure folder exists or is created at build |
+| `apps/traffic-sign-tool/app/_components/layout/Footer.tsx` | Footer links: npm package + JSON sign data |
+| `apps/traffic-sign-tool/messages/en.json`, `messages/de.json` | New Paraglide strings for footer labels |
+| `netlify.toml` | Only if SPA fallback blocks JSON (see Task 5); otherwise unchanged |
 
 ---
 
@@ -222,6 +227,231 @@ pnpm turbo check --filter=@osm-traffic-signs/converter
 
 ---
 
+### Task 5: Static JSON on Netlify deploy preview (smoke-test URLs)
+
+**Context:** Netlify builds PR previews from the monorepo root (`pnpm run build`, publish `apps/traffic-sign-tool/dist`). The `@netlify` bot comment on each PR includes a **Deploy Preview** base URL, e.g. for PR #131:
+
+`https://deploy-preview-131--osm-traffic-sign-preview.netlify.app`
+
+Use that base URL (replace `131` with the current PR number) to verify JSON is served before merging.
+
+**Files:**
+
+- Modify: `apps/traffic-sign-tool/package.json` (`build` script chain)
+- Create (optional): `apps/traffic-sign-tool/scripts/copy-sign-data-json.mjs` — or inline `cp` in `package.json`
+- Modify: `apps/traffic-sign-tool/public/.gitignore` (ignore `public/sign-data/*.json` if generated into `public/`)
+
+- [ ] **Step 1: Copy converter JSON into the app static tree before Vite**
+
+Turbo already runs `^build` first, so `packages/traffic-sign-converter/dist/sign-data/` exists when the app builds.
+
+Add a script (example using Node for cross-platform paths):
+
+```javascript
+// apps/traffic-sign-tool/scripts/copy-sign-data-json.mjs
+import { cpSync, mkdirSync, rmSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..')
+const src = join(root, '../../packages/traffic-sign-converter/dist/sign-data')
+const dest = join(root, 'public/sign-data')
+
+rmSync(dest, { recursive: true, force: true })
+mkdirSync(dest, { recursive: true })
+cpSync(src, dest, { recursive: true })
+```
+
+Wire into app `build` **before** `build:vite`:
+
+```json
+"build:copy-sign-data": "node ./scripts/copy-sign-data-json.mjs",
+"build": "pnpm run build:paraglide && pnpm run build:copy-sign-data && pnpm run build:vite"
+```
+
+Add to `public/.gitignore` (create if missing):
+
+```
+sign-data/*.json
+```
+
+- [ ] **Step 2: Confirm local static URLs**
+
+```bash
+pnpm exec turbo build --filter=osm-traffic-sign-tool
+pnpm --dir apps/traffic-sign-tool preview
+```
+
+In another terminal (default preview port 4173):
+
+```bash
+curl -sS http://localhost:4173/sign-data/manifest.json | head
+curl -sS -o /dev/null -w '%{http_code}\n' http://localhost:4173/sign-data/DE.json
+```
+
+Expected: HTTP `200`, manifest JSON with `"countries": ["DE"]`.
+
+- [ ] **Step 3: Document test links using the Netlify preview URL**
+
+After pushing the implementation PR, read the **Deploy Preview** link from the `@netlify` bot comment (or Netlify deploy log). Substitute it for `{PREVIEW}` below and paste into the PR description / manual QA checklist:
+
+| Resource | URL |
+|----------|-----|
+| Manifest | `{PREVIEW}/sign-data/manifest.json` |
+| Germany signs | `{PREVIEW}/sign-data/DE.json` |
+| General redirects | `{PREVIEW}/sign-data/general-redirects.json` |
+
+**Example (PR #131 plan branch — replace when implementing feature PR):**
+
+- https://deploy-preview-131--osm-traffic-sign-preview.netlify.app/sign-data/manifest.json
+- https://deploy-preview-131--osm-traffic-sign-preview.netlify.app/sign-data/DE.json
+- https://deploy-preview-131--osm-traffic-sign-preview.netlify.app/sign-data/general-redirects.json
+
+Quick checks in browser or terminal:
+
+```bash
+PREVIEW='https://deploy-preview-<PR>--osm-traffic-sign-preview.netlify.app'
+curl -sS "$PREVIEW/sign-data/manifest.json" | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>console.log(JSON.parse(d).countries))"
+curl -sS -o /dev/null -w '%{http_code}\n' "$PREVIEW/sign-data/DE.json"
+```
+
+Expected: prints `DE` (or current country list) and `200`.
+
+**SPA fallback note:** `netlify.toml` rewrites unknown paths to `index.html`. Static files under `dist/sign-data/` are served as files first; if JSON URLs return HTML instead, add an explicit rule *above* the catch-all:
+
+```toml
+[[redirects]]
+  from = "/sign-data/*"
+  to = "/sign-data/:splat"
+  status = 200
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/traffic-sign-tool/package.json apps/traffic-sign-tool/scripts/copy-sign-data-json.mjs apps/traffic-sign-tool/public/.gitignore
+git commit -m "feat(app): copy converter sign-data JSON into static build output"
+```
+
+---
+
+### Task 6: Prepare npm package for manual release
+
+**Scope:** Implementation PR prepares changelog and version policy; a maintainer runs publish manually (do not automate `npm publish` in CI).
+
+**Files:**
+
+- Modify: `packages/traffic-sign-converter/CHANGELOG.md`
+- Modify: `packages/traffic-sign-converter/package.json` (`version` — only bumped during release, not in feature PR unless team prefers)
+- Reference: `release-cli.ts`, `packages/traffic-sign-converter/CONTRIBUTING.md`
+
+- [ ] **Step 1: Finalize `## Unreleased` before release**
+
+Ensure bullets cover at least:
+
+- JSON sign data under `sign-data/` with package export paths (`@osm-traffic-signs/converter/sign-data/DE.json`, manifest, general redirects).
+- README section for npm vs static URL consumption.
+
+Leave `## Unreleased` in the feature PR; do **not** add a version section until release day.
+
+- [ ] **Step 2: Choose semver bump**
+
+Additive, non-breaking API → **minor** bump (current package version `0.4.0` → `0.5.0`), consistent with prior converter releases.
+
+- [ ] **Step 3: Manual release checklist (maintainer)**
+
+Run from repo root after the feature is merged to `main`:
+
+```bash
+bun run release-cli.ts --package --minor
+```
+
+The CLI will:
+
+1. Confirm `CHANGELOG.md` `## Unreleased` is complete.
+2. Run `npm version minor` in `packages/traffic-sign-converter` (updates `package.json` only).
+3. Prompt to move `## Unreleased` content into `## 0.5.0` with date `_YYYY-MM-DD_`.
+4. `turbo build --force` and `pnpm run check` in the package.
+5. `npm publish` (requires `npm login`).
+6. Git commit `Package: release v0.5.0` and optional push.
+
+**Pre-release verification on the tarball:**
+
+```bash
+cd packages/traffic-sign-converter && pnpm run build && npm pack --dry-run
+```
+
+Confirm `package/sign-data/DE.json`, `manifest.json`, and `general-redirects.json` appear in the packed file list.
+
+- [ ] **Step 4: Post-release (optional follow-up PR)**
+
+Bump `apps/traffic-sign-tool` dependency to the published version (`pnpm install` / lockfile) when the app should pin the release; document in app `CHANGELOG.md` if user-facing.
+
+---
+
+### Task 7: TanStack app — footer links (package + JSON)
+
+**Files:**
+
+- Modify: `apps/traffic-sign-tool/app/_components/layout/Footer.tsx`
+- Modify: `apps/traffic-sign-tool/messages/en.json`
+- Modify: `apps/traffic-sign-tool/messages/de.json`
+- Run: `pnpm run build:paraglide` in the app (or full app build)
+
+- [ ] **Step 1: Add Paraglide message keys**
+
+`messages/en.json`:
+
+```json
+"footer_converter_package": "NPM package (@osm-traffic-signs/converter)",
+"footer_sign_data_json": "Sign data (JSON)"
+```
+
+`messages/de.json`:
+
+```json
+"footer_converter_package": "NPM-Paket (@osm-traffic-signs/converter)",
+"footer_sign_data_json": "Zeichendaten (JSON)"
+```
+
+- [ ] **Step 2: Extend `Footer.tsx` navigation**
+
+Add two entries to the **external** `navigation` array (same row as Github / Changelog), reusing existing `footerLinkClassName` and `ExternalLink`:
+
+```tsx
+{
+  name: m.footer_converter_package(),
+  href: 'https://www.npmjs.com/package/@osm-traffic-signs/converter',
+},
+{
+  name: m.footer_sign_data_json(),
+  href: '/sign-data/manifest.json',
+},
+```
+
+Use a plain `<a href="/sign-data/manifest.json">` or `ExternalLink` with **no** `blank` for the JSON link so it stays same-origin on Netlify preview and production. The manifest points consumers at per-country files.
+
+Optional one-line mention in the footer intro paragraph (`footer_project_part` block): short note that tagging logic lives in the npm package — only if it does not clutter; the two links are the minimum.
+
+- [ ] **Step 3: Verify in dev and preview**
+
+```bash
+pnpm --dir apps/traffic-sign-tool dev
+```
+
+Open footer → NPM opens npmjs.com; JSON opens manifest in browser.
+
+After Netlify deploy, confirm JSON link resolves on `{PREVIEW}/sign-data/manifest.json` (Task 5).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/traffic-sign-tool/app/_components/layout/Footer.tsx apps/traffic-sign-tool/messages/en.json apps/traffic-sign-tool/messages/de.json
+git commit -m "feat(app): footer links for converter npm package and JSON sign data"
+```
+
+---
+
 ## Optional follow-ups (not required for issue #120)
 
 - **Tests:** Add a `vitest` test that imports `countryDefinitions` from source and asserts `JSON.stringify` equals `JSON.stringify(JSON.parse(fs.readFileSync('dist/sign-data/DE.json')))` — only if you add a test script phase that runs **after** `build` in CI; otherwise skip to avoid order coupling.
@@ -232,11 +462,14 @@ pnpm turbo check --filter=@osm-traffic-signs/converter
 
 ## Self-review (spec coverage)
 
-| Requirement (from #120 / PR) | Task |
-|-------------------------------|------|
+| Requirement (from #120 / PR / review) | Task |
+|----------------------------------------|------|
 | JSON version of traffic sign data in the NPM build | Task 1 (`dist/sign-data/*.json`) |
 | Easy to consume without TS modules | Task 2 (package exports) + Task 3 (README) |
 | Future countries | Task 1 loop + wildcard export |
+| Test links via Netlify deploy preview | Task 5 (static copy + URL table from bot comment) |
+| Prepare npm package for manual release | Task 6 (changelog, semver, `release-cli.ts` checklist) |
+| App footer: package + JSON feature | Task 7 (`Footer.tsx` + i18n) |
 
 **Placeholder scan:** No TBD/TODO in executable steps above.
 

--- a/docs/superpowers/plans/2026-05-27-converter-json-sign-data-exports.md
+++ b/docs/superpowers/plans/2026-05-27-converter-json-sign-data-exports.md
@@ -4,9 +4,43 @@
 
 **Goal:** Ship plain JSON files alongside the compiled JS in `@osm-traffic-signs/converter` so non-JS consumers (JOSM, StreetComplete, Vespucci, mobile map apps, etc.) can load traffic sign catalogue data — OSM tag mappings, names, descriptions, and image references — without executing TypeScript or bundling the package’s modules. Closes the first milestone of [issue #120](https://github.com/osmberlin/osm-traffic-sign-tool/issues/120).
 
-**Architecture:** Keep the source of truth as today’s TypeScript modules under `src/data-definitions/` (incremental step; unlike [id-tagging-schema](https://github.com/openstreetmap/id-tagging-schema), JSON is a **derived build artifact**, not the edit source — see **Issue #120 alignment** below). After `tsc` emits `dist/`, run a small Bun/Node ESM script that dynamically imports the built `countryDefinitions`, `countryCatalogueMeta`, and `generalRedirects` from `dist/`, then writes UTF-8 JSON under `dist/sign-data/`. Declare stable `package.json` `exports` subpaths for those JSON files. Copy the same JSON tree into the TanStack app’s static output (`public/sign-data/` → Vite `dist/sign-data/`) so Netlify deploy previews and GitHub Pages can serve them over HTTPS for manual smoke tests. Document consumption for non-JS integrators in the converter README; surface the package and JSON URLs in the app footer.
+**Architecture:** Keep the source of truth as today’s TypeScript modules under `src/data-definitions/` (incremental step; unlike [id-tagging-schema](https://github.com/openstreetmap/id-tagging-schema), JSON is a **derived build artifact**, not the edit source — see **Issue #120 alignment** below). After `tsc` emits `dist/`, run a **Bun TypeScript script** (`scripts/write-sign-data-json.ts`, same pattern as `transfer-svgs.ts`) that dynamically imports the built `countryDefinitions`, `countryCatalogueMeta`, and `generalRedirects` from `dist/`, then writes UTF-8 JSON under `dist/sign-data/` using `Bun.write()`. Declare stable `package.json` `exports` subpaths for those JSON files. Copy the same JSON tree into the TanStack app’s static output (`public/sign-data/` → Vite `dist/sign-data/`) so Netlify deploy previews and GitHub Pages can serve them over HTTPS for manual smoke tests. Document consumption for non-JS integrators in the converter README; surface the package and JSON URLs in the app footer.
 
-**Tech Stack:** Bun, Node 22+, `pnpm`, `turbo`, existing `tsc -p tsconfig.build.json` + `copyfiles` build, Vite, TanStack Router, Paraglide i18n, `@arethetypeswrong/cli` (`check-exports`), `vitest`, `bun run release-cli.ts` for manual npm releases, Netlify deploy previews (`netlify.toml`).
+**Tech Stack:** Bun 1.3+ (package manager, script runner, native file APIs), `tsc -p tsconfig.build.json`, Vite, TanStack Router, Paraglide i18n, `@arethetypeswrong/cli` (`check-exports`), `vitest`, `bun run release-cli.ts` for manual npm releases, Netlify deploy previews (`netlify.toml` → `bun run build`).
+
+---
+
+## Monorepo tooling (current — no turbo / no pnpm)
+
+The repo uses **Bun workspaces** only. Turbo and pnpm are gone.
+
+| What | Command / location |
+|------|-------------------|
+| Install | `bun install` |
+| Build everything (Netlify, GH Pages) | `bun run build` at repo root |
+| Build packages (ordered) | `bun run build:packages` — converter **first**, then `@internal/taginfo`, `@internal/svgs`, `@internal/wiki` |
+| Build app | `bun run --cwd apps/traffic-sign-tool build` (after packages) |
+| Lint / format / test all | `bun run check`, `bun run test`, `bun run format` |
+| Pre-push hook | `bun run check` + `bun run check:clean-build` (`.husky/pre-push`) |
+| Clean-build smoke test | `bun run check:clean-build` — wipes all `dist/`, runs full `bun run build` (`script-check-clean-build.ts`) |
+
+**Build order matters:** root `package.json` runs `build:packages` before the app. The converter JSON step belongs in **converter `build`** (Task 1); the app copy step belongs in **app `build`** before Vite (Task 5). No turbo `dependsOn` — ordering is explicit in root scripts.
+
+---
+
+## Where should the JSON writer live?
+
+**Decision: `packages/traffic-sign-converter/scripts/write-sign-data-json.ts`** (not a separate `@internal/*` package).
+
+| Option | Verdict |
+|--------|---------|
+| **`converter/scripts/`** (recommended) | JSON is a **published npm artifact** (`dist/sign-data/` + `exports`). Matches existing `scripts/transfer-svgs.ts` — build glue co-located with the package it produces. |
+| **New `@internal/build` package** | Overkill for one ~60-line script; adds workspace wiring and an extra build step with no reuse today. |
+| **`@internal/svgs` or similar** | Wrong boundary — internal packages own **data pipelines** (wiki download, SVG optimize) that are private and not shipped in `@osm-traffic-signs/converter`. JSON export is part of the public converter release. |
+
+The app’s **`scripts/copy-sign-data-json.ts`** stays in the app (copies from converter `dist/` into `public/` — app-specific static hosting concern).
+
+Use **`.ts`** files run with `bun ./scripts/….ts` (not `.mjs`). Prefer **`Bun.write()`**, **`Bun.file().json()`**, **`import.meta.dir`**, and `node:fs/promises` `cp`/`rm` where appropriate (see `.cursor/rules/bun-helpers.mdc` and `transfer-svgs.ts`).
 
 ---
 
@@ -30,7 +64,9 @@
 - Export **`catalogue-meta.json`** alongside country files (beta/stable, QA capabilities, wiki links).
 - Expect **8 countries** in manifest: `AT`, `AU`, `BE`, `BR`, `CA`, `DE`, `FR`, `PL` (not DE-only).
 - JSON schema reflects **`tagRecommendationsByGeometry`** and **`image: "missing"`** (0.5.0 model).
-- Build/release commands use **`bun`** and next release is **`0.6.0`** (package is already at `0.5.0`).
+- Build/release commands use **`bun`** only (no turbo/pnpm); scripts are **`.ts`** with `Bun.write()` / `import.meta.dir`.
+- JSON writer lives in **`packages/traffic-sign-converter/scripts/`** (not a separate internal package).
+- Next release is **`0.6.0`** (package is already at `0.5.0`).
 
 ---
 
@@ -39,12 +75,13 @@
 | Path | Role |
 |------|------|
 | `packages/traffic-sign-converter/package.json` | Add `build:json` script step, `exports` entries for `./sign-data/*.json`, wire `build` pipeline |
-| `packages/traffic-sign-converter/scripts/write-sign-data-json.mjs` | **Create** — post-`tsc` script: import built modules, `mkdir` `dist/sign-data`, write JSON |
-| `packages/traffic-sign-converter/README.md` | Document JSON subpaths and example `import` / `readFile` usage |
+| `packages/traffic-sign-converter/scripts/write-sign-data-json.ts` | **Create** — post-`tsc` Bun script: import built modules, write `dist/sign-data/*.json` |
+| `packages/traffic-sign-converter/README.md` | Document JSON subpaths and Bun/`Bun.file` consumption examples |
 | `packages/traffic-sign-converter/CHANGELOG.md` | Unreleased bullet for JSON exports |
 | `packages/traffic-sign-converter/src/...` | **No change** to sign data TS (single source of truth unchanged) unless you later dedupe helpers |
-| `apps/traffic-sign-tool/package.json` | Add `build:copy-sign-data` (or similar) before Vite; depends on converter `^build` via turbo |
-| `apps/traffic-sign-tool/public/sign-data/.gitkeep` or `.gitignore` | Generated JSON not committed; ensure folder exists or is created at build |
+| `apps/traffic-sign-tool/scripts/copy-sign-data-json.ts` | **Create** — copy converter `dist/sign-data/` → `public/sign-data/` before Vite |
+| `apps/traffic-sign-tool/package.json` | Add `build:copy-sign-data` before `build:vite`; relies on root `build:packages` order |
+| `apps/traffic-sign-tool/public/.gitignore` | Ignore generated `public/sign-data/*.json` |
 | `apps/traffic-sign-tool/app/_components/layout/Footer.tsx` | Footer links: npm package + JSON sign data |
 | `apps/traffic-sign-tool/messages/en.json`, `messages/de.json` | New Paraglide strings for footer labels |
 | `netlify.toml` | Only if SPA fallback blocks JSON (see Task 5); otherwise unchanged |
@@ -55,27 +92,28 @@
 
 **Files:**
 
-- Create: `packages/traffic-sign-converter/scripts/write-sign-data-json.mjs`
+- Create: `packages/traffic-sign-converter/scripts/write-sign-data-json.ts`
 - Modify: `packages/traffic-sign-converter/package.json` (`build` / `build:json`)
 
-- [ ] **Step 1: Add `write-sign-data-json.mjs`**
+- [ ] **Step 1: Add `write-sign-data-json.ts`**
 
-Use `pathToFileURL` so dynamic `import()` works on all platforms.
+Use `pathToFileURL` for dynamic `import()` of compiled JS; `Bun.write()` for output (see `scripts/transfer-svgs.ts` for repo conventions).
 
-```javascript
-// packages/traffic-sign-converter/scripts/write-sign-data-json.mjs
-import { mkdirSync, writeFileSync } from 'node:fs'
-import { dirname, join } from 'node:path'
-import { fileURLToPath } from 'node:url'
+```typescript
+// packages/traffic-sign-converter/scripts/write-sign-data-json.ts
+import { mkdir } from 'node:fs/promises'
+import path from 'node:path'
 import { pathToFileURL } from 'node:url'
 
-const __dirname = dirname(fileURLToPath(import.meta.url))
-const root = join(__dirname, '..')
-const dist = join(root, 'dist')
-const outDir = join(dist, 'sign-data')
+const packageRoot = path.resolve(import.meta.dir, '..')
+const dist = path.join(packageRoot, 'dist')
+const outDir = path.join(dist, 'sign-data')
 
-function toFileUrl(relativePath) {
-  return pathToFileURL(join(dist, relativePath)).href
+const toFileUrl = (relativePath: string) =>
+  pathToFileURL(path.join(dist, relativePath)).href
+
+const writeJson = async (filename: string, data: unknown) => {
+  await Bun.write(path.join(outDir, filename), `${JSON.stringify(data, null, 2)}\n`)
 }
 
 const { countryDefinitions } = await import(
@@ -88,28 +126,13 @@ const { generalRedirects } = await import(
   toFileUrl('data-definitions/generalRedirects.js'),
 )
 
-mkdirSync(outDir, { recursive: true })
+await mkdir(outDir, { recursive: true })
 
-const jsonOpts = { encoding: 'utf8' }
-
-writeFileSync(
-  join(outDir, 'general-redirects.json'),
-  `${JSON.stringify(generalRedirects, null, 2)}\n`,
-  jsonOpts,
-)
-
-writeFileSync(
-  join(outDir, 'catalogue-meta.json'),
-  `${JSON.stringify(countryCatalogueMeta, null, 2)}\n`,
-  jsonOpts,
-)
+await writeJson('general-redirects.json', generalRedirects)
+await writeJson('catalogue-meta.json', countryCatalogueMeta)
 
 for (const [countryCode, signs] of Object.entries(countryDefinitions)) {
-  writeFileSync(
-    join(outDir, `${countryCode}.json`),
-    `${JSON.stringify(signs, null, 2)}\n`,
-    jsonOpts,
-  )
+  await writeJson(`${countryCode}.json`, signs)
 }
 
 const manifest = {
@@ -129,11 +152,7 @@ const manifest = {
   },
 }
 
-writeFileSync(
-  join(outDir, 'manifest.json'),
-  `${JSON.stringify(manifest, null, 2)}\n`,
-  jsonOpts,
-)
+await writeJson('manifest.json', manifest)
 ```
 
 - [ ] **Step 2: Wire `package.json` scripts**
@@ -141,13 +160,13 @@ writeFileSync(
 After `build:ts` (so `dist/data-definitions/*.js` exists), run the script. Insert into the `build` chain:
 
 ```json
-"build:json": "bun ./scripts/write-sign-data-json.mjs",
+"build:json": "bun ./scripts/write-sign-data-json.ts",
 ```
 
 And extend `build` (order matters: **after** `build:ts`, **before** `build:copy-svgs` is fine):
 
 ```
-"build": "bun run build:clean && ... && bun run build:ts && bun run build:json && bun run build:copy-types && ..."
+"build": "bun run build:clean && bun run build:clean-svgs && bun run build:transfer-svgs && bun run build:ts && bun run build:json && bun run build:copy-types && bun run build:copy-svgs"
 ```
 
 - [ ] **Step 3: Run build and confirm artifacts**
@@ -155,7 +174,7 @@ And extend `build` (order matters: **after** `build:ts`, **before** `build:copy-
 Commands (from repo root):
 
 ```bash
-pnpm exec turbo build --filter=@osm-traffic-signs/converter
+bun run --cwd packages/traffic-sign-converter build
 ```
 
 Expected: files exist:
@@ -168,7 +187,7 @@ Expected: files exist:
 Quick sanity check:
 
 ```bash
-node -e "const m=require('./packages/traffic-sign-converter/dist/sign-data/manifest.json'); console.log(m.countries.join(','))"
+bun -e "const m=await Bun.file('packages/traffic-sign-converter/dist/sign-data/manifest.json').json(); console.log(m.countries.join(','))"
 ```
 
 Expected stdout includes all eight prefixes: `AT,AU,BE,BR,CA,DE,FR,PL` (order may differ).
@@ -176,7 +195,7 @@ Expected stdout includes all eight prefixes: `AT,AU,BE,BR,CA,DE,FR,PL` (order ma
 - [ ] **Step 4: Commit**
 
 ```bash
-git add packages/traffic-sign-converter/scripts/write-sign-data-json.mjs packages/traffic-sign-converter/package.json
+git add packages/traffic-sign-converter/scripts/write-sign-data-json.ts packages/traffic-sign-converter/package.json
 git commit -m "build(converter): emit sign data JSON after TypeScript compile"
 ```
 
@@ -204,7 +223,7 @@ Place them after the main `"."` export block for readability. Wildcard covers `D
 - [ ] **Step 2: Validate with attw**
 
 ```bash
-cd packages/traffic-sign-converter && pnpm run build && pnpm run check-exports
+bun run --cwd packages/traffic-sign-converter build && bun run --cwd packages/traffic-sign-converter check-exports
 ```
 
 Expected: `check-exports` exits 0. If `attw` flags JSON resolution, add the minimal `--ignore-rules` entry **only** after confirming it is a false positive (prefer fixing export conditions first).
@@ -258,16 +277,18 @@ git commit -m "docs(converter): document JSON sign data exports"
 - [ ] **Step 1: Full package check**
 
 ```bash
-cd packages/traffic-sign-converter && pnpm run check
+bun run --cwd packages/traffic-sign-converter check
 ```
 
-Expected: format, exports, lint, type-check, tests all pass.
+Expected: exports, lint, type-check, tests all pass.
 
-- [ ] **Step 2: Root turbo check (optional but recommended pre-push)**
+- [ ] **Step 2: Root clean-build smoke test (recommended pre-push)**
 
 ```bash
-pnpm turbo check --filter=@osm-traffic-signs/converter
+bun run check:clean-build
 ```
+
+Simulates GitHub Pages / Netlify: wipes all `dist/`, runs full `bun run build`. Catches ordering bugs (converter must build before app copy step).
 
 - [ ] **Step 3: Commit** (only if prior steps changed anything, e.g. attw ignores)
 
@@ -275,7 +296,7 @@ pnpm turbo check --filter=@osm-traffic-signs/converter
 
 ### Task 5: Static JSON on Netlify deploy preview (smoke-test URLs)
 
-**Context:** Netlify builds PR previews from the monorepo root (`pnpm run build`, publish `apps/traffic-sign-tool/dist`). The `@netlify` bot comment on each PR includes a **Deploy Preview** base URL, e.g. for PR #131:
+**Context:** Netlify builds PR previews from the monorepo root (`bun run build`, publish `apps/traffic-sign-tool/dist`). Root `build` runs `build:packages` (converter first) then the app build. The `@netlify` bot comment on each PR includes a **Deploy Preview** base URL, e.g. for PR #131:
 
 `https://deploy-preview-131--osm-traffic-sign-preview.netlify.app`
 
@@ -284,35 +305,33 @@ Use that base URL (replace `131` with the current PR number) to verify JSON is s
 **Files:**
 
 - Modify: `apps/traffic-sign-tool/package.json` (`build` script chain)
-- Create (optional): `apps/traffic-sign-tool/scripts/copy-sign-data-json.mjs` — or inline `cp` in `package.json`
-- Modify: `apps/traffic-sign-tool/public/.gitignore` (ignore `public/sign-data/*.json` if generated into `public/`)
+- Create: `apps/traffic-sign-tool/scripts/copy-sign-data-json.ts`
+- Modify: `apps/traffic-sign-tool/public/.gitignore` (ignore `public/sign-data/*.json`)
 
 - [ ] **Step 1: Copy converter JSON into the app static tree before Vite**
 
-Turbo already runs `^build` first, so `packages/traffic-sign-converter/dist/sign-data/` exists when the app builds.
+Root `bun run build` runs `build:packages` first, so `packages/traffic-sign-converter/dist/sign-data/` exists before the app build.
 
-Add a script (example using Node for cross-platform paths):
+Add a Bun script (same `cp` pattern as `transfer-svgs.ts`):
 
-```javascript
-// apps/traffic-sign-tool/scripts/copy-sign-data-json.mjs
-import { cpSync, mkdirSync, rmSync } from 'node:fs'
-import { dirname, join } from 'node:path'
-import { fileURLToPath } from 'node:url'
+```typescript
+// apps/traffic-sign-tool/scripts/copy-sign-data-json.ts
+import { cp, rm } from 'node:fs/promises'
+import path from 'node:path'
 
-const root = join(dirname(fileURLToPath(import.meta.url)), '..')
-const src = join(root, '../../packages/traffic-sign-converter/dist/sign-data')
-const dest = join(root, 'public/sign-data')
+const appRoot = path.resolve(import.meta.dir, '..')
+const src = path.resolve(appRoot, '../../packages/traffic-sign-converter/dist/sign-data')
+const dest = path.join(appRoot, 'public/sign-data')
 
-rmSync(dest, { recursive: true, force: true })
-mkdirSync(dest, { recursive: true })
-cpSync(src, dest, { recursive: true })
+await rm(dest, { recursive: true, force: true })
+await cp(src, dest, { recursive: true })
 ```
 
 Wire into app `build` **before** `build:vite`:
 
 ```json
-"build:copy-sign-data": "node ./scripts/copy-sign-data-json.mjs",
-"build": "pnpm run build:paraglide && pnpm run build:copy-sign-data && pnpm run build:vite"
+"build:copy-sign-data": "bun ./scripts/copy-sign-data-json.ts",
+"build": "bun run build:paraglide && bun run build:copy-sign-data && bun run build:vite"
 ```
 
 Add to `public/.gitignore` (create if missing):
@@ -324,8 +343,8 @@ sign-data/*.json
 - [ ] **Step 2: Confirm local static URLs**
 
 ```bash
-pnpm exec turbo build --filter=osm-traffic-sign-tool
-pnpm --dir apps/traffic-sign-tool preview
+bun run build
+bun run --cwd apps/traffic-sign-tool preview
 ```
 
 In another terminal (default preview port 4173):
@@ -359,7 +378,7 @@ Quick checks in browser or terminal:
 
 ```bash
 PREVIEW='https://deploy-preview-<PR>--osm-traffic-sign-preview.netlify.app'
-curl -sS "$PREVIEW/sign-data/manifest.json" | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>console.log(JSON.parse(d).countries))"
+curl -sS "$PREVIEW/sign-data/manifest.json" | bun -e "const d=await Bun.stdin.text(); console.log(JSON.parse(d).countries)"
 curl -sS -o /dev/null -w '%{http_code}\n' "$PREVIEW/sign-data/DE.json"
 ```
 
@@ -377,7 +396,7 @@ Expected: prints full country list (8 prefixes) and `200`.
 - [ ] **Step 4: Commit**
 
 ```bash
-git add apps/traffic-sign-tool/package.json apps/traffic-sign-tool/scripts/copy-sign-data-json.mjs apps/traffic-sign-tool/public/.gitignore
+git add apps/traffic-sign-tool/package.json apps/traffic-sign-tool/scripts/copy-sign-data-json.ts apps/traffic-sign-tool/public/.gitignore
 git commit -m "feat(app): copy converter sign-data JSON into static build output"
 ```
 
@@ -419,21 +438,22 @@ The CLI will:
 1. Confirm `CHANGELOG.md` `## Unreleased` is complete.
 2. Run `npm version minor` in `packages/traffic-sign-converter` (updates `package.json` only).
 3. Prompt to move `## Unreleased` content into `## 0.6.0` with date `_YYYY-MM-DD_`.
-4. `turbo build --force` and `bun run check` in the package.
+4. `bun run --filter '@osm-traffic-signs/converter' build` and `bun run check` in the package.
 5. `npm publish` (requires `npm login`).
 6. Git commit `Package: release v0.6.0` and optional push.
 
 **Pre-release verification on the tarball:**
 
 ```bash
-cd packages/traffic-sign-converter && pnpm run build && npm pack --dry-run
+bun run --cwd packages/traffic-sign-converter build
+(cd packages/traffic-sign-converter && npm pack --dry-run)
 ```
 
 Confirm `package/sign-data/DE.json`, `catalogue-meta.json`, `manifest.json`, and `general-redirects.json` appear in the packed file list.
 
 - [ ] **Step 4: Post-release (optional follow-up PR)**
 
-Bump `apps/traffic-sign-tool` dependency to the published version (`pnpm install` / lockfile) when the app should pin the release; document in app `CHANGELOG.md` if user-facing.
+Bump `apps/traffic-sign-tool` workspace dependency after publish (`bun install` updates `bun.lock`); document in app `CHANGELOG.md` if user-facing.
 
 ---
 
@@ -444,7 +464,7 @@ Bump `apps/traffic-sign-tool` dependency to the published version (`pnpm install
 - Modify: `apps/traffic-sign-tool/app/_components/layout/Footer.tsx`
 - Modify: `apps/traffic-sign-tool/messages/en.json`
 - Modify: `apps/traffic-sign-tool/messages/de.json`
-- Run: `pnpm run build:paraglide` in the app (or full app build)
+- Run: `bun run --cwd apps/traffic-sign-tool build:paraglide` (or full `bun run build`)
 
 - [ ] **Step 1: Add Paraglide message keys**
 
@@ -484,7 +504,7 @@ Optional one-line mention in the footer intro paragraph (`footer_project_part` b
 - [ ] **Step 3: Verify in dev and preview**
 
 ```bash
-pnpm --dir apps/traffic-sign-tool dev
+bun run --cwd apps/traffic-sign-tool dev
 ```
 
 Open footer → NPM opens npmjs.com; JSON opens manifest in browser.

--- a/docs/superpowers/plans/2026-05-27-converter-json-sign-data-exports.md
+++ b/docs/superpowers/plans/2026-05-27-converter-json-sign-data-exports.md
@@ -2,11 +2,35 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Ship plain JSON files alongside the compiled JS in `@osm-traffic-signs/converter` so consumers can load traffic sign definitions without executing TypeScript or bundling the package’s modules.
+**Goal:** Ship plain JSON files alongside the compiled JS in `@osm-traffic-signs/converter` so non-JS consumers (JOSM, StreetComplete, Vespucci, mobile map apps, etc.) can load traffic sign catalogue data — OSM tag mappings, names, descriptions, and image references — without executing TypeScript or bundling the package’s modules. Closes the first milestone of [issue #120](https://github.com/osmberlin/osm-traffic-sign-tool/issues/120).
 
-**Architecture:** Keep the source of truth as today’s TypeScript modules under `src/data-definitions/`. After `tsc` emits `dist/`, run a small Node ESM script that dynamically imports the built `countryDefinitions` (and `generalRedirects` for redirect metadata used at runtime) from `dist/`, then writes UTF-8 JSON under `dist/sign-data/`. Declare stable `package.json` `exports` subpaths for those JSON files so resolution works under Node 16+ and bundlers. Copy the same JSON tree into the TanStack app’s static output (`public/sign-data/` → Vite `dist/sign-data/`) so Netlify deploy previews and GitHub Pages can serve them over HTTPS for manual smoke tests. Document consumption in the converter README; surface the package and JSON URLs in the app footer.
+**Architecture:** Keep the source of truth as today’s TypeScript modules under `src/data-definitions/` (incremental step; unlike [id-tagging-schema](https://github.com/openstreetmap/id-tagging-schema), JSON is a **derived build artifact**, not the edit source — see **Issue #120 alignment** below). After `tsc` emits `dist/`, run a small Bun/Node ESM script that dynamically imports the built `countryDefinitions`, `countryCatalogueMeta`, and `generalRedirects` from `dist/`, then writes UTF-8 JSON under `dist/sign-data/`. Declare stable `package.json` `exports` subpaths for those JSON files. Copy the same JSON tree into the TanStack app’s static output (`public/sign-data/` → Vite `dist/sign-data/`) so Netlify deploy previews and GitHub Pages can serve them over HTTPS for manual smoke tests. Document consumption for non-JS integrators in the converter README; surface the package and JSON URLs in the app footer.
 
-**Tech Stack:** Node 22+, `pnpm`, `turbo`, existing `tsc` + `copyfiles` build, Vite, TanStack Router, Paraglide i18n, `@arethetypeswrong/cli` (`check-exports`), `vitest`, `bun run release-cli.ts` for manual npm releases, Netlify deploy previews (`netlify.toml`).
+**Tech Stack:** Bun, Node 22+, `pnpm`, `turbo`, existing `tsc -p tsconfig.build.json` + `copyfiles` build, Vite, TanStack Router, Paraglide i18n, `@arethetypeswrong/cli` (`check-exports`), `vitest`, `bun run release-cli.ts` for manual npm releases, Netlify deploy previews (`netlify.toml`).
+
+---
+
+## Issue #120 alignment
+
+[Issue #120 — Separate data from code](https://github.com/osmberlin/osm-traffic-sign-tool/issues/120) asks for sign data (OSM tags ↔ picture/description) in JSON, consumable by editors and apps that are not web/JS-based, and wonders whether an **iD preset** export would make sense.
+
+| #120 goal | This plan | Notes |
+|-----------|-----------|-------|
+| Data separated from code | **Yes (Task 1–2)** | Per-country JSON arrays mirror `SignType` configs; no TS runtime needed to *read* catalogue data. |
+| Language-agnostic consumption | **Yes (Task 3)** | Plain JSON over npm paths or HTTPS static URLs; document schema fields. |
+| OSM tags ↔ sign identity | **Yes** | Each entry has `signId`, `osmValuePart`, `tagRecommendationsByGeometry`, `identifyingTags`, redirects. |
+| Picture / description | **Partial** | `descriptiveName`, `description`, `comments` are in JSON. **Pictures:** `image.sourceUrl` (remote wiki) or `image: "missing"`; bundled SVGs stay in `@osm-traffic-signs/converter/data-svgs/{CC}/svgs/` — pair by `signId` (see Task 3). JSON does not embed SVG bytes. |
+| JSON as edit source (like id-tagging-schema) | **Out of scope** | TS modules remain authoritative; follow-up could invert the pipeline later. |
+| iD preset export | **Out of scope** | Different schema (presets, fields, geometry filters). Worth a **separate issue/spike**: map `tagRecommendationsByGeometry` + `questions` → preset fragments; partial overlap only. Listed under optional follow-ups. |
+| Tag conversion logic in non-JS apps | **Out of scope** | `signsToTags`, conditional merging, question resolution stay in the npm package for now. JSON supplies catalogue + recommendations; reimplementing conversion is a later step for native apps. |
+| Question UI strings | **Partial** | `questions` use `*I18nKey` fields (Paraglide keys), not plain text — non-JS apps need their own translations or a future i18n JSON export. |
+
+**Plan changes vs earlier draft (post-rebase on `main`):**
+
+- Export **`catalogue-meta.json`** alongside country files (beta/stable, QA capabilities, wiki links).
+- Expect **8 countries** in manifest: `AT`, `AU`, `BE`, `BR`, `CA`, `DE`, `FR`, `PL` (not DE-only).
+- JSON schema reflects **`tagRecommendationsByGeometry`** and **`image: "missing"`** (0.5.0 model).
+- Build/release commands use **`bun`** and next release is **`0.6.0`** (package is already at `0.5.0`).
 
 ---
 
@@ -57,6 +81,9 @@ function toFileUrl(relativePath) {
 const { countryDefinitions } = await import(
   toFileUrl('data-definitions/countryDefinitions.js'),
 )
+const { countryCatalogueMeta } = await import(
+  toFileUrl('data-definitions/countryCatalogueMeta.js'),
+)
 const { generalRedirects } = await import(
   toFileUrl('data-definitions/generalRedirects.js'),
 )
@@ -71,6 +98,12 @@ writeFileSync(
   jsonOpts,
 )
 
+writeFileSync(
+  join(outDir, 'catalogue-meta.json'),
+  `${JSON.stringify(countryCatalogueMeta, null, 2)}\n`,
+  jsonOpts,
+)
+
 for (const [countryCode, signs] of Object.entries(countryDefinitions)) {
   writeFileSync(
     join(outDir, `${countryCode}.json`),
@@ -81,12 +114,18 @@ for (const [countryCode, signs] of Object.entries(countryDefinitions)) {
 
 const manifest = {
   version: 1,
+  schemaNote:
+    'Each {CC}.json is SignType[]; fields match TrafficSignDataTypes (tagRecommendationsByGeometry, image, questions, …).',
   countries: Object.keys(countryDefinitions).sort(),
   files: {
     countries: Object.fromEntries(
       Object.keys(countryDefinitions).map((c) => [c, `./${c}.json`]),
     ),
+    catalogueMeta: './catalogue-meta.json',
     generalRedirects: './general-redirects.json',
+  },
+  relatedAssets: {
+    bundledSvgs: '@osm-traffic-signs/converter/data-svgs/{CC}/svgs/{signId}.svg',
   },
 }
 
@@ -102,13 +141,13 @@ writeFileSync(
 After `build:ts` (so `dist/data-definitions/*.js` exists), run the script. Insert into the `build` chain:
 
 ```json
-"build:json": "node ./scripts/write-sign-data-json.mjs",
+"build:json": "bun ./scripts/write-sign-data-json.mjs",
 ```
 
 And extend `build` (order matters: **after** `build:ts`, **before** `build:copy-svgs` is fine):
 
 ```
-"build": "... && npm run build:ts && npm run build:json && npm run build:copy-types && ..."
+"build": "bun run build:clean && ... && bun run build:ts && bun run build:json && bun run build:copy-types && ..."
 ```
 
 - [ ] **Step 3: Run build and confirm artifacts**
@@ -121,17 +160,18 @@ pnpm exec turbo build --filter=@osm-traffic-signs/converter
 
 Expected: files exist:
 
-- `packages/traffic-sign-converter/dist/sign-data/DE.json`
+- `packages/traffic-sign-converter/dist/sign-data/DE.json` (and `AT.json`, `FR.json`, …)
+- `packages/traffic-sign-converter/dist/sign-data/catalogue-meta.json`
 - `packages/traffic-sign-converter/dist/sign-data/general-redirects.json`
 - `packages/traffic-sign-converter/dist/sign-data/manifest.json`
 
 Quick sanity check:
 
 ```bash
-node -e "const m=require('./packages/traffic-sign-converter/dist/sign-data/manifest.json'); console.log(m.countries)"
+node -e "const m=require('./packages/traffic-sign-converter/dist/sign-data/manifest.json'); console.log(m.countries.join(','))"
 ```
 
-Expected stdout includes `DE`.
+Expected stdout includes all eight prefixes: `AT,AU,BE,BR,CA,DE,FR,PL` (order may differ).
 
 - [ ] **Step 4: Commit**
 
@@ -154,6 +194,7 @@ Add subpaths (adjust if you drop `manifest.json` in Task 1):
 
 ```json
 "./sign-data/manifest.json": "./dist/sign-data/manifest.json",
+"./sign-data/catalogue-meta.json": "./dist/sign-data/catalogue-meta.json",
 "./sign-data/general-redirects.json": "./dist/sign-data/general-redirects.json",
 "./sign-data/*.json": "./dist/sign-data/*.json"
 ```
@@ -188,13 +229,18 @@ git commit -m "feat(converter): export sign-data JSON paths in package exports"
 
 Add a **JSON sign data** section after **Main data**, documenting:
 
-- `import manifest from '@osm-traffic-signs/converter/sign-data/manifest.json' assert { type: 'json' }` (or `with { type: 'json' }` depending on target) **or** `readFile` + `JSON.parse` for CJS-style consumers.
-- Per-country: `@osm-traffic-signs/converter/sign-data/DE.json`
-- `general-redirects.json` and its purpose (cross-cutting redirect map, not part of per-country arrays).
+- Start from `manifest.json` → per-country files; read `catalogue-meta.json` for beta/stable and QA capability flags.
+- Per-country: `@osm-traffic-signs/converter/sign-data/DE.json` (array of sign objects).
+- `general-redirects.json` — cross-cutting redirect map used at lookup time.
+- **Non-JS integrators (issue #120):**
+  - Schema matches `TrafficSignDataTypes` / exported TS types (`tagRecommendationsByGeometry`, `questions` with `*I18nKey`, `image` as remote object, local object, or `"missing"`).
+  - **Pictures:** use `image.sourceUrl` when remote; for bundled assets import/copy from `@osm-traffic-signs/converter/data-svgs/{CC}/svgs/` (filename derived from `signId`, same rules as `createSvgFilename`).
+  - **Conversion logic** (`signsToTags`, question merging) is not in JSON — use the npm package or reimplement from published recommendations.
+  - Link to [issue #120](https://github.com/osmberlin/osm-traffic-sign-tool/issues/120) as tracking issue; note iD preset export is not included (future work).
 
 - [ ] **Step 2: Changelog bullet**
 
-Under `## Unreleased`, add a line such as: ship JSON copies of country sign lists, general redirects, and a small manifest under `sign-data/` with stable package export paths.
+Under `## Unreleased`, add a line such as: ship JSON copies of country sign lists, catalogue metadata, general redirects, and a manifest under `sign-data/` with stable package export paths (addresses #120 data separation).
 
 - [ ] **Step 3: Commit**
 
@@ -289,7 +335,7 @@ curl -sS http://localhost:4173/sign-data/manifest.json | head
 curl -sS -o /dev/null -w '%{http_code}\n' http://localhost:4173/sign-data/DE.json
 ```
 
-Expected: HTTP `200`, manifest JSON with `"countries": ["DE"]`.
+Expected: HTTP `200`, manifest JSON whose `countries` array lists all configured prefixes (e.g. includes `"DE"` and `"FR"`).
 
 - [ ] **Step 3: Document test links using the Netlify preview URL**
 
@@ -298,7 +344,9 @@ After pushing the implementation PR, read the **Deploy Preview** link from the `
 | Resource | URL |
 |----------|-----|
 | Manifest | `{PREVIEW}/sign-data/manifest.json` |
+| Catalogue metadata | `{PREVIEW}/sign-data/catalogue-meta.json` |
 | Germany signs | `{PREVIEW}/sign-data/DE.json` |
+| France signs (beta) | `{PREVIEW}/sign-data/FR.json` |
 | General redirects | `{PREVIEW}/sign-data/general-redirects.json` |
 
 **Example (PR #131 plan branch — replace when implementing feature PR):**
@@ -315,7 +363,7 @@ curl -sS "$PREVIEW/sign-data/manifest.json" | node -e "let d='';process.stdin.on
 curl -sS -o /dev/null -w '%{http_code}\n' "$PREVIEW/sign-data/DE.json"
 ```
 
-Expected: prints `DE` (or current country list) and `200`.
+Expected: prints full country list (8 prefixes) and `200`.
 
 **SPA fallback note:** `netlify.toml` rewrites unknown paths to `index.html`. Static files under `dist/sign-data/` are served as files first; if JSON URLs return HTML instead, add an explicit rule *above* the catch-all:
 
@@ -356,7 +404,7 @@ Leave `## Unreleased` in the feature PR; do **not** add a version section until 
 
 - [ ] **Step 2: Choose semver bump**
 
-Additive, non-breaking API → **minor** bump (current package version `0.4.0` → `0.5.0`), consistent with prior converter releases.
+Additive, non-breaking API → **minor** bump (current package version `0.5.0` → `0.6.0`), consistent with prior converter releases.
 
 - [ ] **Step 3: Manual release checklist (maintainer)**
 
@@ -370,10 +418,10 @@ The CLI will:
 
 1. Confirm `CHANGELOG.md` `## Unreleased` is complete.
 2. Run `npm version minor` in `packages/traffic-sign-converter` (updates `package.json` only).
-3. Prompt to move `## Unreleased` content into `## 0.5.0` with date `_YYYY-MM-DD_`.
-4. `turbo build --force` and `pnpm run check` in the package.
+3. Prompt to move `## Unreleased` content into `## 0.6.0` with date `_YYYY-MM-DD_`.
+4. `turbo build --force` and `bun run check` in the package.
 5. `npm publish` (requires `npm login`).
-6. Git commit `Package: release v0.5.0` and optional push.
+6. Git commit `Package: release v0.6.0` and optional push.
 
 **Pre-release verification on the tarball:**
 
@@ -381,7 +429,7 @@ The CLI will:
 cd packages/traffic-sign-converter && pnpm run build && npm pack --dry-run
 ```
 
-Confirm `package/sign-data/DE.json`, `manifest.json`, and `general-redirects.json` appear in the packed file list.
+Confirm `package/sign-data/DE.json`, `catalogue-meta.json`, `manifest.json`, and `general-redirects.json` appear in the packed file list.
 
 - [ ] **Step 4: Post-release (optional follow-up PR)**
 
@@ -452,8 +500,12 @@ git commit -m "feat(app): footer links for converter npm package and JSON sign d
 
 ---
 
-## Optional follow-ups (not required for issue #120)
+## Optional follow-ups (beyond issue #120 milestone 1)
 
+- **iD preset export (#120 question):** Spike mapping `SignType` → [id-tagging-schema](https://github.com/openstreetmap/id-tagging-schema) preset JSON; likely needs custom fields for modifiers, geometry-specific recommendations, and question flows. Track as separate issue.
+- **JSON as source of truth:** Invert pipeline (edit JSON → generate TS) like id-tagging-schema; large migration.
+- **i18n bundle for questions:** Export Paraglide message keys used in `questions` as `{locale}.json` for native apps.
+- **Picture index JSON:** Flat `{countryPrefix}/{signId} → {url|svgPath}` lookup file for map renderers.
 - **Tests:** Add a `vitest` test that imports `countryDefinitions` from source and asserts `JSON.stringify` equals `JSON.stringify(JSON.parse(fs.readFileSync('dist/sign-data/DE.json')))` — only if you add a test script phase that runs **after** `build` in CI; otherwise skip to avoid order coupling.
 - **Minified JSON:** Switch to `JSON.stringify(x)` without pretty-print to shrink tarball; trade-off: worse `git diff` on accidental commits (dist is not usually committed).
 - **Single combined file:** If consumers prefer one download, add `all-countries.json` with the same shape as `countryDefinitions` — redundant with per-country files; add only if requested.
@@ -464,12 +516,14 @@ git commit -m "feat(app): footer links for converter npm package and JSON sign d
 
 | Requirement (from #120 / PR / review) | Task |
 |----------------------------------------|------|
-| JSON version of traffic sign data in the NPM build | Task 1 (`dist/sign-data/*.json`) |
-| Easy to consume without TS modules | Task 2 (package exports) + Task 3 (README) |
-| Future countries | Task 1 loop + wildcard export |
-| Test links via Netlify deploy preview | Task 5 (static copy + URL table from bot comment) |
-| Prepare npm package for manual release | Task 6 (changelog, semver, `release-cli.ts` checklist) |
-| App footer: package + JSON feature | Task 7 (`Footer.tsx` + i18n) |
+| Separate catalogue data from TS/code (#120) | Task 1–2 |
+| Non-JS consumption (tags, names, descriptions) | Task 2–3 (exports + integrator README) |
+| Image references (not embedded SVG) | Task 1 + Task 3 (`relatedAssets` in manifest, data-svgs docs) |
+| Multi-country catalogues (AT…BR) | Task 1 loop + `catalogue-meta.json` |
+| iD preset export (#120 question) | Optional follow-up (out of scope) |
+| Test links via Netlify deploy preview | Task 5 |
+| Prepare npm package for manual release | Task 6 (`0.6.0`) |
+| App footer: package + JSON feature | Task 7 |
 
 **Placeholder scan:** No TBD/TODO in executable steps above.
 

--- a/docs/superpowers/plans/2026-05-27-converter-json-sign-data-exports.md
+++ b/docs/superpowers/plans/2026-05-27-converter-json-sign-data-exports.md
@@ -1,0 +1,257 @@
+# Converter package: JSON sign data exports — implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship plain JSON files alongside the compiled JS in `@osm-traffic-signs/converter` so consumers can load traffic sign definitions without executing TypeScript or bundling the package’s modules.
+
+**Architecture:** Keep the source of truth as today’s TypeScript modules under `src/data-definitions/`. After `tsc` emits `dist/`, run a small Node ESM script that dynamically imports the built `countryDefinitions` (and `generalRedirects` for redirect metadata used at runtime) from `dist/`, then writes UTF-8 JSON under `dist/sign-data/`. Declare stable `package.json` `exports` subpaths for those JSON files so resolution works under Node 16+ and bundlers. Document consumption in the converter README.
+
+**Tech Stack:** Node 22+, `pnpm`, existing `tsc` + `copyfiles` build, `@arethetypeswrong/cli` (`check-exports`), `vitest`.
+
+---
+
+## File map (before tasks)
+
+| Path | Role |
+|------|------|
+| `packages/traffic-sign-converter/package.json` | Add `build:json` script step, `exports` entries for `./sign-data/*.json`, wire `build` pipeline |
+| `packages/traffic-sign-converter/scripts/write-sign-data-json.mjs` | **Create** — post-`tsc` script: import built modules, `mkdir` `dist/sign-data`, write JSON |
+| `packages/traffic-sign-converter/README.md` | Document JSON subpaths and example `import` / `readFile` usage |
+| `packages/traffic-sign-converter/CHANGELOG.md` | Unreleased bullet for JSON exports |
+| `packages/traffic-sign-converter/src/...` | **No change** to sign data TS (single source of truth unchanged) unless you later dedupe helpers |
+
+---
+
+### Task 1: Post-build JSON writer script
+
+**Files:**
+
+- Create: `packages/traffic-sign-converter/scripts/write-sign-data-json.mjs`
+- Modify: `packages/traffic-sign-converter/package.json` (`build` / `build:json`)
+
+- [ ] **Step 1: Add `write-sign-data-json.mjs`**
+
+Use `pathToFileURL` so dynamic `import()` works on all platforms.
+
+```javascript
+// packages/traffic-sign-converter/scripts/write-sign-data-json.mjs
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { pathToFileURL } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const root = join(__dirname, '..')
+const dist = join(root, 'dist')
+const outDir = join(dist, 'sign-data')
+
+function toFileUrl(relativePath) {
+  return pathToFileURL(join(dist, relativePath)).href
+}
+
+const { countryDefinitions } = await import(
+  toFileUrl('data-definitions/countryDefinitions.js'),
+)
+const { generalRedirects } = await import(
+  toFileUrl('data-definitions/generalRedirects.js'),
+)
+
+mkdirSync(outDir, { recursive: true })
+
+const jsonOpts = { encoding: 'utf8' }
+
+writeFileSync(
+  join(outDir, 'general-redirects.json'),
+  `${JSON.stringify(generalRedirects, null, 2)}\n`,
+  jsonOpts,
+)
+
+for (const [countryCode, signs] of Object.entries(countryDefinitions)) {
+  writeFileSync(
+    join(outDir, `${countryCode}.json`),
+    `${JSON.stringify(signs, null, 2)}\n`,
+    jsonOpts,
+  )
+}
+
+const manifest = {
+  version: 1,
+  countries: Object.keys(countryDefinitions).sort(),
+  files: {
+    countries: Object.fromEntries(
+      Object.keys(countryDefinitions).map((c) => [c, `./${c}.json`]),
+    ),
+    generalRedirects: './general-redirects.json',
+  },
+}
+
+writeFileSync(
+  join(outDir, 'manifest.json'),
+  `${JSON.stringify(manifest, null, 2)}\n`,
+  jsonOpts,
+)
+```
+
+- [ ] **Step 2: Wire `package.json` scripts**
+
+After `build:ts` (so `dist/data-definitions/*.js` exists), run the script. Insert into the `build` chain:
+
+```json
+"build:json": "node ./scripts/write-sign-data-json.mjs",
+```
+
+And extend `build` (order matters: **after** `build:ts`, **before** `build:copy-svgs` is fine):
+
+```
+"build": "... && npm run build:ts && npm run build:json && npm run build:copy-types && ..."
+```
+
+- [ ] **Step 3: Run build and confirm artifacts**
+
+Commands (from repo root):
+
+```bash
+pnpm exec turbo build --filter=@osm-traffic-signs/converter
+```
+
+Expected: files exist:
+
+- `packages/traffic-sign-converter/dist/sign-data/DE.json`
+- `packages/traffic-sign-converter/dist/sign-data/general-redirects.json`
+- `packages/traffic-sign-converter/dist/sign-data/manifest.json`
+
+Quick sanity check:
+
+```bash
+node -e "const m=require('./packages/traffic-sign-converter/dist/sign-data/manifest.json'); console.log(m.countries)"
+```
+
+Expected stdout includes `DE`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/traffic-sign-converter/scripts/write-sign-data-json.mjs packages/traffic-sign-converter/package.json
+git commit -m "build(converter): emit sign data JSON after TypeScript compile"
+```
+
+---
+
+### Task 2: `package.json` exports for JSON
+
+**Files:**
+
+- Modify: `packages/traffic-sign-converter/package.json` (`exports`)
+
+- [ ] **Step 1: Add export map entries**
+
+Add subpaths (adjust if you drop `manifest.json` in Task 1):
+
+```json
+"./sign-data/manifest.json": "./dist/sign-data/manifest.json",
+"./sign-data/general-redirects.json": "./dist/sign-data/general-redirects.json",
+"./sign-data/*.json": "./dist/sign-data/*.json"
+```
+
+Place them after the main `"."` export block for readability. Wildcard covers `DE.json` and future country codes without editing `package.json` each time.
+
+- [ ] **Step 2: Validate with attw**
+
+```bash
+cd packages/traffic-sign-converter && pnpm run build && pnpm run check-exports
+```
+
+Expected: `check-exports` exits 0. If `attw` flags JSON resolution, add the minimal `--ignore-rules` entry **only** after confirming it is a false positive (prefer fixing export conditions first).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/traffic-sign-converter/package.json
+git commit -m "feat(converter): export sign-data JSON paths in package exports"
+```
+
+---
+
+### Task 3: Documentation and changelog
+
+**Files:**
+
+- Modify: `packages/traffic-sign-converter/README.md`
+- Modify: `packages/traffic-sign-converter/CHANGELOG.md` (`## Unreleased`)
+
+- [ ] **Step 1: README section**
+
+Add a **JSON sign data** section after **Main data**, documenting:
+
+- `import manifest from '@osm-traffic-signs/converter/sign-data/manifest.json' assert { type: 'json' }` (or `with { type: 'json' }` depending on target) **or** `readFile` + `JSON.parse` for CJS-style consumers.
+- Per-country: `@osm-traffic-signs/converter/sign-data/DE.json`
+- `general-redirects.json` and its purpose (cross-cutting redirect map, not part of per-country arrays).
+
+- [ ] **Step 2: Changelog bullet**
+
+Under `## Unreleased`, add a line such as: ship JSON copies of country sign lists, general redirects, and a small manifest under `sign-data/` with stable package export paths.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/traffic-sign-converter/README.md packages/traffic-sign-converter/CHANGELOG.md
+git commit -m "docs(converter): document JSON sign data exports"
+```
+
+---
+
+### Task 4: Monorepo verification
+
+**Files:** none (commands only)
+
+- [ ] **Step 1: Full package check**
+
+```bash
+cd packages/traffic-sign-converter && pnpm run check
+```
+
+Expected: format, exports, lint, type-check, tests all pass.
+
+- [ ] **Step 2: Root turbo check (optional but recommended pre-push)**
+
+```bash
+pnpm turbo check --filter=@osm-traffic-signs/converter
+```
+
+- [ ] **Step 3: Commit** (only if prior steps changed anything, e.g. attw ignores)
+
+---
+
+## Optional follow-ups (not required for issue #120)
+
+- **Tests:** Add a `vitest` test that imports `countryDefinitions` from source and asserts `JSON.stringify` equals `JSON.stringify(JSON.parse(fs.readFileSync('dist/sign-data/DE.json')))` — only if you add a test script phase that runs **after** `build` in CI; otherwise skip to avoid order coupling.
+- **Minified JSON:** Switch to `JSON.stringify(x)` without pretty-print to shrink tarball; trade-off: worse `git diff` on accidental commits (dist is not usually committed).
+- **Single combined file:** If consumers prefer one download, add `all-countries.json` with the same shape as `countryDefinitions` — redundant with per-country files; add only if requested.
+
+---
+
+## Self-review (spec coverage)
+
+| Requirement (from #120 / PR) | Task |
+|-------------------------------|------|
+| JSON version of traffic sign data in the NPM build | Task 1 (`dist/sign-data/*.json`) |
+| Easy to consume without TS modules | Task 2 (package exports) + Task 3 (README) |
+| Future countries | Task 1 loop + wildcard export |
+
+**Placeholder scan:** No TBD/TODO in executable steps above.
+
+**Type consistency:** JSON matches runtime arrays exported as `countryDefinitions[code]`; manifest `version: 1` leaves room for schema changes later.
+
+---
+
+## Execution handoff
+
+**Plan complete and saved to** `docs/superpowers/plans/2026-05-27-converter-json-sign-data-exports.md`.
+
+**Two execution options:**
+
+1. **Subagent-Driven (recommended)** — Dispatch a fresh subagent per task, review between tasks.
+
+2. **Inline Execution** — Run tasks in one session using executing-plans-style checkpoints.
+
+**Which approach?** (Pick when handing this to an implementer.)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implementation plan for [issue #120](https://github.com/osmberlin/osm-traffic-sign-tool/issues/120) — JSON exports for `@osm-traffic-signs/converter`.

**Latest revision covers:**
- Issue #120 alignment (data separation, non-JS consumers, iD presets out of scope)
- **Bun-only** tooling — no turbo/pnpm; native `Bun.write()`, `import.meta.dir`, `.ts` scripts
- **Script placement:** `packages/traffic-sign-converter/scripts/write-sign-data-json.ts` (not a separate internal package); app copy script in `apps/traffic-sign-tool/scripts/`
- Current monorepo build: `bun run build` → `build:packages` (converter first) → app; verify with `bun run check:clean-build`
- Multi-country JSON + `catalogue-meta.json`; release `0.6.0`

Plan-only PR — implementation follows this doc.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6b6c073d-b1db-467c-a685-fc9695ea7291"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6b6c073d-b1db-467c-a685-fc9695ea7291"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

