### PR TITLE
Packages: Add JSON exports for sign data

### DIFF
--- a/apps/traffic-sign-tool/app/_components/layout/Footer.tsx
+++ b/apps/traffic-sign-tool/app/_components/layout/Footer.tsx
@@ -23,14 +23,27 @@ export const Footer = () => {
     {
       name: m.footer_imprint(),
       href: 'https://www.osm-verkehrswende.org/contact',
+      blank: true,
     },
     {
       name: m.footer_changelog(),
       href: 'https://github.com/osmberlin/osm-traffic-sign-tool/blob/main/apps/traffic-sign-tool/CHANGELOG.md',
+      blank: true,
     },
     {
       name: m.footer_github(),
       href: 'https://github.com/osmberlin/osm-traffic-sign-tool',
+      blank: true,
+    },
+    {
+      name: m.footer_converter_package(),
+      href: 'https://www.npmjs.com/package/@osm-traffic-signs/converter',
+      blank: true,
+    },
+    {
+      name: m.footer_sign_data_json(),
+      href: '/sign-data/manifest.json',
+      blank: false,
     },
   ]
 
@@ -88,7 +101,7 @@ export const Footer = () => {
           {navigation.map((item) => {
             return (
               <div key={item.href} className="px-5 py-2">
-                <ExternalLink href={item.href} className={footerLinkClassName} blank>
+                <ExternalLink href={item.href} className={footerLinkClassName} blank={item.blank}>
                   {item.name}
                 </ExternalLink>
               </div>

--- a/apps/traffic-sign-tool/messages/de.json
+++ b/apps/traffic-sign-tool/messages/de.json
@@ -33,6 +33,8 @@
   "footer_combinations_qa": "Zeichenkombinations-QA",
   "footer_questions_qa": "Zeichenfragen-QA",
   "footer_all_signs": "Alle Zeichen",
+  "footer_converter_package": "NPM-Paket (@osm-traffic-signs/converter)",
+  "footer_sign_data_json": "Zeichendaten (JSON)",
   "qa_pages_nav_label": "QA-Seiten:",
   "qa_pages_nav_aria_label": "QA-Seiten",
   "qa_pages_nav_taginfo": "Taginfo",

--- a/apps/traffic-sign-tool/messages/en.json
+++ b/apps/traffic-sign-tool/messages/en.json
@@ -33,6 +33,8 @@
   "footer_combinations_qa": "Sign combinations QA",
   "footer_questions_qa": "Sign questions QA",
   "footer_all_signs": "All signs",
+  "footer_converter_package": "NPM package (@osm-traffic-signs/converter)",
+  "footer_sign_data_json": "Sign data (JSON)",
   "qa_pages_nav_label": "QA-Pages:",
   "qa_pages_nav_aria_label": "QA pages",
   "qa_pages_nav_taginfo": "Taginfo",

--- a/apps/traffic-sign-tool/package.json
+++ b/apps/traffic-sign-tool/package.json
@@ -7,7 +7,8 @@
   "type": "module",
   "scripts": {
     "bleach": "rm -rf node_modules && rm -rf dist/",
-    "build": "bun run build:paraglide && bun run build:vite",
+    "build": "bun run build:paraglide && bun run build:copy-sign-data && bun run build:vite",
+    "build:copy-sign-data": "bun ./scripts/copy-sign-data-json.ts",
     "build:gh-pages": "bun run build && cp dist/index.html dist/404.html",
     "build:paraglide": "paraglide-js compile --project ./project.inlang --outdir ./paraglide --strategy localStorage baseLocale",
     "build:vite": "vite build",

--- a/apps/traffic-sign-tool/public/.gitignore
+++ b/apps/traffic-sign-tool/public/.gitignore
@@ -1,0 +1,1 @@
+sign-data/*.json

--- a/apps/traffic-sign-tool/scripts/copy-sign-data-json.ts
+++ b/apps/traffic-sign-tool/scripts/copy-sign-data-json.ts
@@ -1,0 +1,15 @@
+import { cp, rm } from 'node:fs/promises'
+import path from 'node:path'
+
+const appRoot = path.resolve(import.meta.dir, '..')
+const src = path.resolve(appRoot, '../../packages/traffic-sign-converter/dist/sign-data')
+const dest = path.join(appRoot, 'public/sign-data')
+
+if (!(await Bun.file(path.join(src, 'manifest.json')).exists())) {
+  throw new Error(
+    `Missing converter sign-data at ${src}. Run converter build first (bun run build:packages).`,
+  )
+}
+
+await rm(dest, { recursive: true, force: true })
+await cp(src, dest, { recursive: true })

--- a/packages/traffic-sign-converter/CHANGELOG.md
+++ b/packages/traffic-sign-converter/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Ship JSON sign data under `sign-data/` (per-country catalogues, `catalogue-meta.json`, `general-redirects.json`, `manifest.json`) with package export paths for non-JS consumers ([#120](https://github.com/osmberlin/osm-traffic-sign-tool/issues/120)).
+
 ## 0.5.0
 
 _2026-06-06_

--- a/packages/traffic-sign-converter/README.md
+++ b/packages/traffic-sign-converter/README.md
@@ -27,6 +27,38 @@ npm install @osm-traffic-signs/converter
 
 Use `countryDefinitions` to access the traffic sign objects per country.
 
+## JSON sign data
+
+Build output includes plain JSON under `sign-data/` for language-agnostic consumption (see [issue #120](https://github.com/osmberlin/osm-traffic-sign-tool/issues/120)).
+
+Start from the manifest, then load per-country files:
+
+```typescript
+const manifest = await Bun.file(
+  new URL('@osm-traffic-signs/converter/sign-data/manifest.json', import.meta.url),
+).json()
+const deSigns = await Bun.file(
+  new URL('@osm-traffic-signs/converter/sign-data/DE.json', import.meta.url),
+).json()
+```
+
+| File                                 | Path                                                            |
+| ------------------------------------ | --------------------------------------------------------------- |
+| Manifest (country list + file map)   | `@osm-traffic-signs/converter/sign-data/manifest.json`          |
+| Catalogue metadata (beta/stable, QA) | `@osm-traffic-signs/converter/sign-data/catalogue-meta.json`    |
+| Cross-country redirects              | `@osm-traffic-signs/converter/sign-data/general-redirects.json` |
+| Per-country sign arrays              | `@osm-traffic-signs/converter/sign-data/{CC}.json`              |
+
+Each `{CC}.json` file is a `SignType[]` matching `TrafficSignDataTypes` (`tagRecommendationsByGeometry`, `questions` with `*I18nKey`, `image` as remote object, local object, or `"missing"`).
+
+**Pictures:** use `image.sourceUrl` when remote. For bundled SVGs, load from `@osm-traffic-signs/converter/data-svgs/{CC}/svgs/` (filename from `signId`, same rules as `createSvgFilename`).
+
+**Conversion logic** (`signsToTags`, question merging) is not in JSON — use this package’s functions or reimplement from the published recommendations.
+
+**Static URLs:** the web app also serves the same files at `/sign-data/` (GitHub Pages / Netlify preview).
+
+iD preset export is not included; track separately if needed.
+
 ## Example usage
 
 `TODO`

--- a/packages/traffic-sign-converter/package.json
+++ b/packages/traffic-sign-converter/package.json
@@ -46,15 +46,20 @@
       "import": "./dist/data-svgs/*/svgs/*.svg",
       "default": "./dist/data-svgs/*/svgs/*.svg",
       "types": "./dist/types/svg.d.ts"
-    }
+    },
+    "./sign-data/manifest.json": "./dist/sign-data/manifest.json",
+    "./sign-data/catalogue-meta.json": "./dist/sign-data/catalogue-meta.json",
+    "./sign-data/general-redirects.json": "./dist/sign-data/general-redirects.json",
+    "./sign-data/*.json": "./dist/sign-data/*.json"
   },
   "scripts": {
     "bleach": "rm -rf node_modules && rm -rf dist",
-    "build": "bun run build:clean && bun run build:clean-svgs && bun run build:transfer-svgs && bun run build:ts && bun run build:copy-types && bun run build:copy-svgs",
+    "build": "bun run build:clean && bun run build:clean-svgs && bun run build:transfer-svgs && bun run build:ts && bun run build:json && bun run build:copy-types && bun run build:copy-svgs",
     "build:clean": "rimraf dist",
     "build:clean-svgs": "rimraf ./src/data-svgs",
     "build:copy-svgs": "copyfiles -u 1 'src/data-svgs/**' 'dist'",
     "build:copy-types": "copyfiles --flat './src/types/svg.d.ts' './dist/types'",
+    "build:json": "bun ./scripts/write-sign-data-json.ts",
     "build:transfer-svgs": "bun ./scripts/transfer-svgs.ts",
     "build:ts": "tsc -p tsconfig.build.json",
     "build:watch": "tsc -p tsconfig.build.json --watch",

--- a/packages/traffic-sign-converter/scripts/write-sign-data-json.ts
+++ b/packages/traffic-sign-converter/scripts/write-sign-data-json.ts
@@ -1,0 +1,45 @@
+import { mkdir } from 'node:fs/promises'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+const packageRoot = path.resolve(import.meta.dir, '..')
+const dist = path.join(packageRoot, 'dist')
+const outDir = path.join(dist, 'sign-data')
+
+const toFileUrl = (relativePath: string) => pathToFileURL(path.join(dist, relativePath)).href
+
+const writeJson = async (filename: string, data: unknown) => {
+  await Bun.write(path.join(outDir, filename), `${JSON.stringify(data, null, 2)}\n`)
+}
+
+const { countryDefinitions } = await import(toFileUrl('data-definitions/countryDefinitions.js'))
+const { countryCatalogueMeta } = await import(toFileUrl('data-definitions/countryCatalogueMeta.js'))
+const { generalRedirects } = await import(toFileUrl('data-definitions/generalRedirects.js'))
+
+await mkdir(outDir, { recursive: true })
+
+await writeJson('general-redirects.json', generalRedirects)
+await writeJson('catalogue-meta.json', countryCatalogueMeta)
+
+for (const [countryCode, signs] of Object.entries(countryDefinitions)) {
+  await writeJson(`${countryCode}.json`, signs)
+}
+
+const manifest = {
+  version: 1,
+  schemaNote:
+    'Each {CC}.json is SignType[]; fields match TrafficSignDataTypes (tagRecommendationsByGeometry, image, questions, …).',
+  countries: Object.keys(countryDefinitions).sort(),
+  files: {
+    countries: Object.fromEntries(
+      Object.keys(countryDefinitions).map((countryCode) => [countryCode, `./${countryCode}.json`]),
+    ),
+    catalogueMeta: './catalogue-meta.json',
+    generalRedirects: './general-redirects.json',
+  },
+  relatedAssets: {
+    bundledSvgs: '@osm-traffic-signs/converter/data-svgs/{CC}/svgs/{signId}.svg',
+  },
+}
+
+await writeJson('manifest.json', manifest)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements the JSON sign data export plan for [issue #120](https://github.com/osmberlin/osm-traffic-sign-tool/issues/120).

## Converter package

- **`build:json`** — `scripts/write-sign-data-json.ts` writes `dist/sign-data/` after `tsc`:
  - Per-country catalogues (`AT.json` … `PL.json`)
  - `manifest.json`, `catalogue-meta.json`, `general-redirects.json`
- **Package exports** for `@osm-traffic-signs/converter/sign-data/*.json` (attw ✅)
- **README** — consumption guide for non-JS integrators
- **CHANGELOG** — Unreleased entry

## Web app

- **`build:copy-sign-data`** — copies converter JSON into `public/sign-data/` before Vite (served at `/sign-data/` on GH Pages / Netlify)
- **Footer** — links to npm package and `/sign-data/manifest.json`

## Verification

- `bun run --cwd packages/traffic-sign-converter check` — pass
- `bun run check:clean-build` — pass
- `npm pack --dry-run` — includes all `dist/sign-data/*.json`

## Manual QA after Netlify deploy

Replace `{PREVIEW}` with the deploy preview URL from the `@netlify` bot comment:

| Resource | URL |
|----------|-----|
| Manifest | `{PREVIEW}/sign-data/manifest.json` |
| Catalogue metadata | `{PREVIEW}/sign-data/catalogue-meta.json` |
| Germany signs | `{PREVIEW}/sign-data/DE.json` |
| General redirects | `{PREVIEW}/sign-data/general-redirects.json` |

## Release

Maintainer: `bun run release-cli.ts --package --minor` → **0.6.0** after merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6b6c073d-b1db-467c-a685-fc9695ea7291"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6b6c073d-b1db-467c-a685-fc9695ea7291"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

