### PR TITLE
Fix wiki Tag template parsing which uses `3=`

### DIFF
--- a/packages/internal_svgs/script-import-wiki-catalogue.ts
+++ b/packages/internal_svgs/script-import-wiki-catalogue.ts
@@ -270,14 +270,24 @@ const parseWikiTagTemplates = (tagsText: string): { key: string; value: string }
 const parseEqualsFormatWikiTags = (tagsText: string): { key: string; value: string }[] => {
   const tags: { key: string; value: string }[] = []
   const normalized = tagsText.replace(/\s+/g, ' ')
+  const keyPattern = /([a-z0-9:_-]+)\s*=\s*/gi
   for (const segment of normalized.split(/\s*\+\s*/)) {
     const trimmed = segment.trim()
     if (!trimmed || trimmed.includes('{{Tag|')) continue
-    const eqIndex = trimmed.search(/(?<=[a-z0-9:_-])\s*=/)
-    if (eqIndex === -1) continue
-    const key = trimmed.slice(0, eqIndex).trim()
-    if (!/^[a-z0-9:_-]+$/i.test(key)) continue
-    pushWikiTag(tags, key, trimmed.slice(eqIndex + 1))
+    const matches = [...trimmed.matchAll(keyPattern)]
+    for (let index = 0; index < matches.length; index++) {
+      const match = matches[index]!
+      const key = match[1]!.trim()
+      if (!/^[a-z0-9:_-]+$/i.test(key) || /^\d+$/.test(key)) continue
+      const valueStart = match.index! + match[0].length
+      let valueEnd = index + 1 < matches.length ? matches[index + 1]!.index! : trimmed.length
+      if (index + 1 < matches.length && /^\d+$/.test(matches[index + 1]![1]!)) {
+        valueEnd =
+          index + 2 < matches.length ? matches[index + 2]!.index! : trimmed.length
+        index += 1
+      }
+      pushWikiTag(tags, key, trimmed.slice(valueStart, valueEnd))
+    }
   }
   return tags
 }

--- a/packages/internal_svgs/script-import-wiki-catalogue.ts
+++ b/packages/internal_svgs/script-import-wiki-catalogue.ts
@@ -240,12 +240,15 @@ const normalizeWikiTagValue = (value: string): string => {
   return trimmed
 }
 
+const trimWikiTagListSeparator = (value: string): string =>
+  value.replace(/[,;]\s*$/, '').trim()
+
 const pushWikiTag = (
   tags: { key: string; value: string }[],
   key: string,
   rawValue: string,
 ): void => {
-  const value = normalizeWikiTagValue(rawValue)
+  const value = trimWikiTagListSeparator(normalizeWikiTagValue(rawValue))
   if (key === 'traffic_sign' || !value || value === '*' || value === '=*') return
   if (!tags.some((t) => t.key === key && t.value === value)) {
     tags.push({ key, value })

--- a/packages/internal_svgs/script-import-wiki-catalogue.ts
+++ b/packages/internal_svgs/script-import-wiki-catalogue.ts
@@ -252,6 +252,18 @@ const pushWikiTag = (
   }
 }
 
+const stripWikiTagTemplates = (segment: string): string =>
+  segment.replace(/\{\{Tag\|[^}]+\}\}/gi, ' ').trim()
+
+const isInsideParentheses = (text: string, index: number): boolean => {
+  let depth = 0
+  for (let i = 0; i < index; i++) {
+    if (text[i] === '(') depth++
+    else if (text[i] === ')') depth = Math.max(0, depth - 1)
+  }
+  return depth > 0
+}
+
 const parseWikiTagTemplates = (tagsText: string): { key: string; value: string }[] => {
   const tags: { key: string; value: string }[] = []
   const templatePatterns = [
@@ -272,21 +284,22 @@ const parseEqualsFormatWikiTags = (tagsText: string): { key: string; value: stri
   const normalized = tagsText.replace(/\s+/g, ' ')
   const keyPattern = /([a-z0-9:_-]+)\s*=\s*/gi
   for (const segment of normalized.split(/\s*\+\s*/)) {
-    const trimmed = segment.trim()
-    if (!trimmed || trimmed.includes('{{Tag|')) continue
-    const matches = [...trimmed.matchAll(keyPattern)]
+    const plainText = stripWikiTagTemplates(segment.trim())
+    if (!plainText) continue
+    const matches = [...plainText.matchAll(keyPattern)].filter(
+      (match) => !isInsideParentheses(plainText, match.index!),
+    )
     for (let index = 0; index < matches.length; index++) {
       const match = matches[index]!
       const key = match[1]!.trim()
       if (!/^[a-z0-9:_-]+$/i.test(key) || /^\d+$/.test(key)) continue
       const valueStart = match.index! + match[0].length
-      let valueEnd = index + 1 < matches.length ? matches[index + 1]!.index! : trimmed.length
+      let valueEnd = index + 1 < matches.length ? matches[index + 1]!.index! : plainText.length
       if (index + 1 < matches.length && /^\d+$/.test(matches[index + 1]![1]!)) {
-        valueEnd =
-          index + 2 < matches.length ? matches[index + 2]!.index! : trimmed.length
+        valueEnd = index + 2 < matches.length ? matches[index + 2]!.index! : plainText.length
         index += 1
       }
-      pushWikiTag(tags, key, trimmed.slice(valueStart, valueEnd))
+      pushWikiTag(tags, key, plainText.slice(valueStart, valueEnd))
     }
   }
   return tags

--- a/packages/internal_svgs/script-import-wiki-catalogue.ts
+++ b/packages/internal_svgs/script-import-wiki-catalogue.ts
@@ -232,6 +232,56 @@ const parsePolishDescriptionTagCell = (tagsText: string): { key: string; value: 
   return tags
 }
 
+/** OSM wiki {{Tag}} templates use `3=` or `||` before the value to mean "do not link the value". */
+const normalizeWikiTagValue = (value: string): string => {
+  const trimmed = value.replace(/`/g, '').trim()
+  if (trimmed.startsWith('||')) return trimmed.slice(2).trim()
+  if (trimmed.startsWith('3=')) return trimmed.slice(2).trim()
+  return trimmed
+}
+
+const pushWikiTag = (
+  tags: { key: string; value: string }[],
+  key: string,
+  rawValue: string,
+): void => {
+  const value = normalizeWikiTagValue(rawValue)
+  if (key === 'traffic_sign' || !value || value === '*' || value === '=*') return
+  if (!tags.some((t) => t.key === key && t.value === value)) {
+    tags.push({ key, value })
+  }
+}
+
+const parseWikiTagTemplates = (tagsText: string): { key: string; value: string }[] => {
+  const tags: { key: string; value: string }[] = []
+  const templatePatterns = [
+    /\{\{Tag\|([^|{}]+)\|\|([^}]+)\}\}/gi,
+    /\{\{Tag\|([^|{}]+)\|3=([^}]+)\}\}/gi,
+    /\{\{Tag\|([^|{}]+)\|([^|{}]+)\}\}/gi,
+  ]
+  for (const pattern of templatePatterns) {
+    for (const match of tagsText.matchAll(pattern)) {
+      pushWikiTag(tags, match[1]!.trim(), match[2]!)
+    }
+  }
+  return tags
+}
+
+const parseEqualsFormatWikiTags = (tagsText: string): { key: string; value: string }[] => {
+  const tags: { key: string; value: string }[] = []
+  const normalized = tagsText.replace(/\s+/g, ' ')
+  for (const segment of normalized.split(/\s*\+\s*/)) {
+    const trimmed = segment.trim()
+    if (!trimmed || trimmed.includes('{{Tag|')) continue
+    const eqIndex = trimmed.search(/(?<=[a-z0-9:_-])\s*=/)
+    if (eqIndex === -1) continue
+    const key = trimmed.slice(0, eqIndex).trim()
+    if (!/^[a-z0-9:_-]+$/i.test(key)) continue
+    pushWikiTag(tags, key, trimmed.slice(eqIndex + 1))
+  }
+  return tags
+}
+
 const parseWikiTags = (tagsText: string): { key: string; value: string }[] => {
   if (!tagsText || /^(n\/a|na|–|-|\*|= \*)$/i.test(tagsText.trim())) return []
 
@@ -241,18 +291,16 @@ const parseWikiTags = (tagsText: string): { key: string; value: string }[] => {
   }
 
   const tags: { key: string; value: string }[] = []
+  for (const tag of parseWikiTagTemplates(tagsText)) {
+    pushWikiTag(tags, tag.key, tag.value)
+  }
+
   const normalized = tagsText.replace(/\s+/g, ' ')
-  const tagPatterns = [
-    ...normalized.matchAll(/([a-z0-9:_-]+)\s*=\s*([^`\s,;]+(?:\[[^\]]+\])?)/gi),
-    ...normalized.matchAll(/([a-z0-9:_-]+)\s+([a-z0-9:_*-]+)\s*`=`/gi),
-  ]
-  for (const match of tagPatterns) {
-    const key = match[1]!
-    const value = match[2]!.replace(/`/g, '')
-    if (key === 'traffic_sign' || value === '*' || value === '=*') continue
-    if (!tags.some((t) => t.key === key && t.value === value)) {
-      tags.push({ key, value })
-    }
+  for (const tag of parseEqualsFormatWikiTags(normalized)) {
+    pushWikiTag(tags, tag.key, tag.value)
+  }
+  for (const match of normalized.matchAll(/([a-z0-9:_-]+)\s+([a-z0-9:_*-]+)\s*`=`/gi)) {
+    pushWikiTag(tags, match[1]!, match[2]!)
   }
   return tags
 }

--- a/packages/internal_wiki/src/data/trafficSignsWiki_AU.json
+++ b/packages/internal_wiki/src/data/trafficSignsWiki_AU.json
@@ -36,7 +36,7 @@
     "imageSvg": "https://upload.wikimedia.org/wikipedia/commons/d/de/Australia_R5-1_%28vertical_-_one_time%29.svg",
     "imageUrl": "https://wiki.openstreetmap.org/wiki/File:Australia_R5-1_(vertical_-_one_time).svg",
     "name": "R5-1",
-    "osmTags": ["maxstay:conditional=1"],
+    "osmTags": ["maxstay:conditional=1 hour @ (Sa 09:00-12:00)"],
     "comments": ""
   },
   {

--- a/packages/internal_wiki/src/parseWiki/parseWikiTables.test.ts
+++ b/packages/internal_wiki/src/parseWiki/parseWikiTables.test.ts
@@ -165,6 +165,29 @@ describe('parseWikiTags', () => {
     })
   })
 
+  describe('comma-separated tags in one segment (DE 1024-17)', () => {
+    test('parses motor_vehicle and agricultural tags from DE wiki combination text', () => {
+      expect(parseWikiTags('motor_vehicle=no, agricultural=yes')).toEqual([
+        { key: 'motor_vehicle', value: 'no' },
+        { key: 'agricultural', value: 'yes' },
+      ])
+    })
+
+    test('parses vehicle and agricultural tags separated by comma', () => {
+      expect(parseWikiTags('vehicle=no, agricultural=yes')).toEqual([
+        { key: 'vehicle', value: 'no' },
+        { key: 'agricultural', value: 'yes' },
+      ])
+    })
+
+    test('parses semicolon-separated hazard alternatives', () => {
+      expect(parseWikiTags('hazard=curve; hazard=turn')).toEqual([
+        { key: 'hazard', value: 'curve' },
+        { key: 'hazard', value: 'turn' },
+      ])
+    })
+  })
+
   describe('space-separated tags in one segment (FR A1a)', () => {
     test('parses hazard tag alongside skipped traffic_sign from rendered FR:A1a cell', () => {
       expect(parseWikiTags('traffic_sign=FR:A1a hazard=turn')).toEqual([
@@ -188,40 +211,40 @@ describe('parseWikiTags', () => {
   })
 
   describe('equals inside conditionals (AU R6-17)', () => {
-  test('parses AU R6-17 axle-group conditional from rendered wiki cell text', () => {
-    expect(
-      parseWikiTags(
-        'bridge=yes + maxweight:conditional=X @ (axles=1); X @ (axles=2); X @ (axles=3)',
-      ),
-    ).toEqual([
-      { key: 'bridge', value: 'yes' },
-      {
-        key: 'maxweight:conditional',
-        value: 'X @ (axles=1); X @ (axles=2); X @ (axles=3)',
-      },
-    ])
-  })
-
-  test('parses AU R6-17 axle-group conditional from wiki Tag templates', () => {
-    expect(
-      parseWikiTags(
-        '{{Tag|bridge|yes}} + {{Tag|maxweight:conditional|3=X @ (axles=1); X @ (axles=2); X @ (axles=3)}}',
-      ),
-    ).toEqual(
-      expect.arrayContaining([
+    test('parses AU R6-17 axle-group conditional from rendered wiki cell text', () => {
+      expect(
+        parseWikiTags(
+          'bridge=yes + maxweight:conditional=X @ (axles=1); X @ (axles=2); X @ (axles=3)',
+        ),
+      ).toEqual([
         { key: 'bridge', value: 'yes' },
         {
           key: 'maxweight:conditional',
           value: 'X @ (axles=1); X @ (axles=2); X @ (axles=3)',
         },
-      ]),
-    )
-    expect(
-      parseWikiTags(
-        '{{Tag|bridge|yes}} + {{Tag|maxweight:conditional|3=X @ (axles=1); X @ (axles=2); X @ (axles=3)}}',
-      ),
-    ).toHaveLength(2)
-  })
+      ])
+    })
+
+    test('parses AU R6-17 axle-group conditional from wiki Tag templates', () => {
+      expect(
+        parseWikiTags(
+          '{{Tag|bridge|yes}} + {{Tag|maxweight:conditional|3=X @ (axles=1); X @ (axles=2); X @ (axles=3)}}',
+        ),
+      ).toEqual(
+        expect.arrayContaining([
+          { key: 'bridge', value: 'yes' },
+          {
+            key: 'maxweight:conditional',
+            value: 'X @ (axles=1); X @ (axles=2); X @ (axles=3)',
+          },
+        ]),
+      )
+      expect(
+        parseWikiTags(
+          '{{Tag|bridge|yes}} + {{Tag|maxweight:conditional|3=X @ (axles=1); X @ (axles=2); X @ (axles=3)}}',
+        ),
+      ).toHaveLength(2)
+    })
 
     test('parses FR SC1b destination conditional with comparison operator', () => {
       expect(
@@ -247,33 +270,33 @@ describe('parseWikiTags', () => {
   })
 
   describe('plain tags alongside wiki Tag templates', () => {
-  test('parses AU R4-V105 school zone tags from rendered wiki cell text', () => {
-    expect(
-      parseWikiTags(
-        'maxspeed:conditional=40 @ (Mo-Fr 08:00-09:30,14:30-16:00; PH off; SH off) + hazard=school_zone',
-      ),
-    ).toEqual([
-      {
-        key: 'maxspeed:conditional',
-        value: '40 @ (Mo-Fr 08:00-09:30,14:30-16:00; PH off; SH off)',
-      },
-      { key: 'hazard', value: 'school_zone' },
-    ])
-  })
+    test('parses AU R4-V105 school zone tags from rendered wiki cell text', () => {
+      expect(
+        parseWikiTags(
+          'maxspeed:conditional=40 @ (Mo-Fr 08:00-09:30,14:30-16:00; PH off; SH off) + hazard=school_zone',
+        ),
+      ).toEqual([
+        {
+          key: 'maxspeed:conditional',
+          value: '40 @ (Mo-Fr 08:00-09:30,14:30-16:00; PH off; SH off)',
+        },
+        { key: 'hazard', value: 'school_zone' },
+      ])
+    })
 
-  test('parses AU R4-V105 school zone tags from wiki Tag templates', () => {
-    expect(
-      parseWikiTags(
-        '{{Tag|maxspeed:conditional|3=40 @ (Mo-Fr 08:00-09:30,14:30-16:00; PH off; SH off)}} + {{Tag|hazard|school_zone}}',
-      ),
-    ).toEqual([
-      {
-        key: 'maxspeed:conditional',
-        value: '40 @ (Mo-Fr 08:00-09:30,14:30-16:00; PH off; SH off)',
-      },
-      { key: 'hazard', value: 'school_zone' },
-    ])
-  })
+    test('parses AU R4-V105 school zone tags from wiki Tag templates', () => {
+      expect(
+        parseWikiTags(
+          '{{Tag|maxspeed:conditional|3=40 @ (Mo-Fr 08:00-09:30,14:30-16:00; PH off; SH off)}} + {{Tag|hazard|school_zone}}',
+        ),
+      ).toEqual([
+        {
+          key: 'maxspeed:conditional',
+          value: '40 @ (Mo-Fr 08:00-09:30,14:30-16:00; PH off; SH off)',
+        },
+        { key: 'hazard', value: 'school_zone' },
+      ])
+    })
 
     test('parses plain tags in the same segment as wiki Tag templates', () => {
       expect(parseWikiTags('{{Tag|bridge|yes}} maxspeed=10')).toEqual([

--- a/packages/internal_wiki/src/parseWiki/parseWikiTables.test.ts
+++ b/packages/internal_wiki/src/parseWiki/parseWikiTables.test.ts
@@ -137,9 +137,9 @@ describe('parseWikiTags', () => {
   })
 
   test('strips wiki Tag template 3= value prefix', () => {
-    expect(
-      parseWikiTags('{{Tag|maxstay:conditional|3=1 hour @ (Sa 09:00-12:00)}}'),
-    ).toEqual([{ key: 'maxstay:conditional', value: '1 hour @ (Sa 09:00-12:00)' }])
+    expect(parseWikiTags('{{Tag|maxstay:conditional|3=1 hour @ (Sa 09:00-12:00)}}')).toEqual([
+      { key: 'maxstay:conditional', value: '1 hour @ (Sa 09:00-12:00)' },
+    ])
     expect(parseWikiTags('maxstay:conditional=3=1 hour @ (Sa 09:00-12:00)')).toEqual([
       { key: 'maxstay:conditional', value: '1 hour @ (Sa 09:00-12:00)' },
     ])

--- a/packages/internal_wiki/src/parseWiki/parseWikiTables.test.ts
+++ b/packages/internal_wiki/src/parseWiki/parseWikiTables.test.ts
@@ -160,6 +160,12 @@ describe('parseWikiTags', () => {
       { key: 'maxspeed:bus', value: '40' },
     ])
   })
+
+  test('parses multiple space-separated tags in one segment', () => {
+    expect(parseWikiTags('traffic_sign=FR:A1a hazard=turn')).toEqual([
+      { key: 'hazard', value: 'turn' },
+    ])
+  })
 })
 
 describe('normalizeWikiTagValue', () => {

--- a/packages/internal_wiki/src/parseWiki/parseWikiTables.test.ts
+++ b/packages/internal_wiki/src/parseWiki/parseWikiTables.test.ts
@@ -130,43 +130,64 @@ const frSu1RowHtml = `
 </table>`
 
 describe('parseWikiTags', () => {
-  test('parses conditional maxstay values with spaces', () => {
-    expect(parseWikiTags('maxstay:conditional=1 hour @ (Sa 09:00-12:00)')).toEqual([
-      { key: 'maxstay:conditional', value: '1 hour @ (Sa 09:00-12:00)' },
-    ])
+  describe('wiki Tag template 3= and || prefixes (AU R5-1)', () => {
+    test('parses conditional maxstay values with spaces from rendered AU:R5-1 cell', () => {
+      expect(parseWikiTags('maxstay:conditional=1 hour @ (Sa 09:00-12:00)')).toEqual([
+        { key: 'maxstay:conditional', value: '1 hour @ (Sa 09:00-12:00)' },
+      ])
+    })
+
+    test('strips 3= prefix from wikitext and rendered equals format', () => {
+      expect(parseWikiTags('{{Tag|maxstay:conditional|3=1 hour @ (Sa 09:00-12:00)}}')).toEqual([
+        { key: 'maxstay:conditional', value: '1 hour @ (Sa 09:00-12:00)' },
+      ])
+      expect(parseWikiTags('maxstay:conditional=3=1 hour @ (Sa 09:00-12:00)')).toEqual([
+        { key: 'maxstay:conditional', value: '1 hour @ (Sa 09:00-12:00)' },
+      ])
+    })
+
+    test('strips || prefix from wikitext and rendered equals format', () => {
+      expect(parseWikiTags('{{Tag|maxspeed:conditional||40 @ (09:00-18:00)}}')).toEqual([
+        { key: 'maxspeed:conditional', value: '40 @ (09:00-18:00)' },
+      ])
+      expect(parseWikiTags('maxspeed:conditional=||40 @ (09:00-18:00)')).toEqual([
+        { key: 'maxspeed:conditional', value: '40 @ (09:00-18:00)' },
+      ])
+    })
+
+    test('parses FR destination tags using || no-link prefix', () => {
+      expect(parseWikiTags('{{Tag|destination:access:goods||no}}')).toEqual([
+        { key: 'destination:access:goods', value: 'no' },
+      ])
+      expect(parseWikiTags('{{Tag|destination:access:maxweightrating:goods||5.5}}')).toEqual([
+        { key: 'destination:access:maxweightrating:goods', value: '5.5' },
+      ])
+    })
   })
 
-  test('strips wiki Tag template 3= value prefix', () => {
-    expect(parseWikiTags('{{Tag|maxstay:conditional|3=1 hour @ (Sa 09:00-12:00)}}')).toEqual([
-      { key: 'maxstay:conditional', value: '1 hour @ (Sa 09:00-12:00)' },
-    ])
-    expect(parseWikiTags('maxstay:conditional=3=1 hour @ (Sa 09:00-12:00)')).toEqual([
-      { key: 'maxstay:conditional', value: '1 hour @ (Sa 09:00-12:00)' },
-    ])
+  describe('space-separated tags in one segment (FR A1a)', () => {
+    test('parses hazard tag alongside skipped traffic_sign from rendered FR:A1a cell', () => {
+      expect(parseWikiTags('traffic_sign=FR:A1a hazard=turn')).toEqual([
+        { key: 'hazard', value: 'turn' },
+      ])
+    })
+
+    test('parses multiple AU R4-246 speed tags separated by plus', () => {
+      expect(parseWikiTags('maxspeed:hgv=40 + maxspeed:bus=40')).toEqual([
+        { key: 'maxspeed:hgv', value: '40' },
+        { key: 'maxspeed:bus', value: '40' },
+      ])
+    })
+
+    test('parses AU R5-20 parking tags from rendered wiki cell', () => {
+      expect(parseWikiTags('parking:side:access=no + parking:side:bus=designated')).toEqual([
+        { key: 'parking:side:access', value: 'no' },
+        { key: 'parking:side:bus', value: 'designated' },
+      ])
+    })
   })
 
-  test('strips wiki Tag template || value prefix', () => {
-    expect(parseWikiTags('{{Tag|maxspeed:conditional||40 @ (09:00-18:00)}}')).toEqual([
-      { key: 'maxspeed:conditional', value: '40 @ (09:00-18:00)' },
-    ])
-    expect(parseWikiTags('maxspeed:conditional=||40 @ (09:00-18:00)')).toEqual([
-      { key: 'maxspeed:conditional', value: '40 @ (09:00-18:00)' },
-    ])
-  })
-
-  test('parses multiple tags separated by plus', () => {
-    expect(parseWikiTags('maxspeed:hgv=40 + maxspeed:bus=40')).toEqual([
-      { key: 'maxspeed:hgv', value: '40' },
-      { key: 'maxspeed:bus', value: '40' },
-    ])
-  })
-
-  test('parses multiple space-separated tags in one segment', () => {
-    expect(parseWikiTags('traffic_sign=FR:A1a hazard=turn')).toEqual([
-      { key: 'hazard', value: 'turn' },
-    ])
-  })
-
+  describe('equals inside conditionals (AU R6-17)', () => {
   test('parses AU R6-17 axle-group conditional from rendered wiki cell text', () => {
     expect(
       parseWikiTags(
@@ -202,6 +223,30 @@ describe('parseWikiTags', () => {
     ).toHaveLength(2)
   })
 
+    test('parses FR SC1b destination conditional with comparison operator', () => {
+      expect(
+        parseWikiTags('destination:access:goods:conditional=designated @ (weightrating > 5.5)'),
+      ).toEqual([
+        {
+          key: 'destination:access:goods:conditional',
+          value: 'designated @ (weightrating > 5.5)',
+        },
+      ])
+    })
+
+    test('parses AU R9-1-1 restriction conditional from rendered wiki cell', () => {
+      expect(
+        parseWikiTags('restriction:conditional=restriction-value @ (Mo-Fr 07:00-09:30)'),
+      ).toEqual([
+        {
+          key: 'restriction:conditional',
+          value: 'restriction-value @ (Mo-Fr 07:00-09:30)',
+        },
+      ])
+    })
+  })
+
+  describe('plain tags alongside wiki Tag templates', () => {
   test('parses AU R4-V105 school zone tags from rendered wiki cell text', () => {
     expect(
       parseWikiTags(
@@ -230,11 +275,19 @@ describe('parseWikiTags', () => {
     ])
   })
 
-  test('parses plain tags in the same segment as wiki Tag templates', () => {
-    expect(parseWikiTags('{{Tag|bridge|yes}} maxspeed=10')).toEqual([
-      { key: 'bridge', value: 'yes' },
-      { key: 'maxspeed', value: '10' },
-    ])
+    test('parses plain tags in the same segment as wiki Tag templates', () => {
+      expect(parseWikiTags('{{Tag|bridge|yes}} maxspeed=10')).toEqual([
+        { key: 'bridge', value: 'yes' },
+        { key: 'maxspeed', value: '10' },
+      ])
+    })
+
+    test('parses AU W5-V129 hazard and bridge tags from rendered wiki cell', () => {
+      expect(parseWikiTags('hazard:conditional=slippery @ icy + bridge=yes')).toEqual([
+        { key: 'hazard:conditional', value: 'slippery @ icy' },
+        { key: 'bridge', value: 'yes' },
+      ])
+    })
   })
 })
 
@@ -360,6 +413,12 @@ describe('parseUniversalTable', () => {
     expect(row?.name).toBe(
       'Direction conseillée aux véhicules de transport de marchandises dont le poids total autorisé en charge ou le poids total roulant autorisé excède le nombre indiqué',
     )
+  })
+
+  test('parses space-separated FR A1a hazard tag from rendered wiki row', () => {
+    const $ = cheerio.load(frA1aRowHtml)
+    const [row] = parseUniversalTable($, 'FR')
+    expect(toWikiSign('FR', row!)?.osmTags).toEqual(['hazard=turn'])
   })
 })
 

--- a/packages/internal_wiki/src/parseWiki/parseWikiTables.test.ts
+++ b/packages/internal_wiki/src/parseWiki/parseWikiTables.test.ts
@@ -166,6 +166,76 @@ describe('parseWikiTags', () => {
       { key: 'hazard', value: 'turn' },
     ])
   })
+
+  test('parses AU R6-17 axle-group conditional from rendered wiki cell text', () => {
+    expect(
+      parseWikiTags(
+        'bridge=yes + maxweight:conditional=X @ (axles=1); X @ (axles=2); X @ (axles=3)',
+      ),
+    ).toEqual([
+      { key: 'bridge', value: 'yes' },
+      {
+        key: 'maxweight:conditional',
+        value: 'X @ (axles=1); X @ (axles=2); X @ (axles=3)',
+      },
+    ])
+  })
+
+  test('parses AU R6-17 axle-group conditional from wiki Tag templates', () => {
+    expect(
+      parseWikiTags(
+        '{{Tag|bridge|yes}} + {{Tag|maxweight:conditional|3=X @ (axles=1); X @ (axles=2); X @ (axles=3)}}',
+      ),
+    ).toEqual(
+      expect.arrayContaining([
+        { key: 'bridge', value: 'yes' },
+        {
+          key: 'maxweight:conditional',
+          value: 'X @ (axles=1); X @ (axles=2); X @ (axles=3)',
+        },
+      ]),
+    )
+    expect(
+      parseWikiTags(
+        '{{Tag|bridge|yes}} + {{Tag|maxweight:conditional|3=X @ (axles=1); X @ (axles=2); X @ (axles=3)}}',
+      ),
+    ).toHaveLength(2)
+  })
+
+  test('parses AU R4-V105 school zone tags from rendered wiki cell text', () => {
+    expect(
+      parseWikiTags(
+        'maxspeed:conditional=40 @ (Mo-Fr 08:00-09:30,14:30-16:00; PH off; SH off) + hazard=school_zone',
+      ),
+    ).toEqual([
+      {
+        key: 'maxspeed:conditional',
+        value: '40 @ (Mo-Fr 08:00-09:30,14:30-16:00; PH off; SH off)',
+      },
+      { key: 'hazard', value: 'school_zone' },
+    ])
+  })
+
+  test('parses AU R4-V105 school zone tags from wiki Tag templates', () => {
+    expect(
+      parseWikiTags(
+        '{{Tag|maxspeed:conditional|3=40 @ (Mo-Fr 08:00-09:30,14:30-16:00; PH off; SH off)}} + {{Tag|hazard|school_zone}}',
+      ),
+    ).toEqual([
+      {
+        key: 'maxspeed:conditional',
+        value: '40 @ (Mo-Fr 08:00-09:30,14:30-16:00; PH off; SH off)',
+      },
+      { key: 'hazard', value: 'school_zone' },
+    ])
+  })
+
+  test('parses plain tags in the same segment as wiki Tag templates', () => {
+    expect(parseWikiTags('{{Tag|bridge|yes}} maxspeed=10')).toEqual([
+      { key: 'bridge', value: 'yes' },
+      { key: 'maxspeed', value: '10' },
+    ])
+  })
 })
 
 describe('normalizeWikiTagValue', () => {

--- a/packages/internal_wiki/src/parseWiki/parseWikiTables.test.ts
+++ b/packages/internal_wiki/src/parseWiki/parseWikiTables.test.ts
@@ -3,8 +3,10 @@ import { describe, expect, test } from 'vitest'
 import {
   cleanWikiSignName,
   extractDeTrafficSignValue,
+  normalizeWikiTagValue,
   parseDeRowIdTable,
   parseUniversalTable,
+  parseWikiTags,
   toWikiSign,
 } from './parseWikiTables.js'
 
@@ -126,6 +128,48 @@ const frSu1RowHtml = `
     </tr>
   </tbody>
 </table>`
+
+describe('parseWikiTags', () => {
+  test('parses conditional maxstay values with spaces', () => {
+    expect(parseWikiTags('maxstay:conditional=1 hour @ (Sa 09:00-12:00)')).toEqual([
+      { key: 'maxstay:conditional', value: '1 hour @ (Sa 09:00-12:00)' },
+    ])
+  })
+
+  test('strips wiki Tag template 3= value prefix', () => {
+    expect(
+      parseWikiTags('{{Tag|maxstay:conditional|3=1 hour @ (Sa 09:00-12:00)}}'),
+    ).toEqual([{ key: 'maxstay:conditional', value: '1 hour @ (Sa 09:00-12:00)' }])
+    expect(parseWikiTags('maxstay:conditional=3=1 hour @ (Sa 09:00-12:00)')).toEqual([
+      { key: 'maxstay:conditional', value: '1 hour @ (Sa 09:00-12:00)' },
+    ])
+  })
+
+  test('strips wiki Tag template || value prefix', () => {
+    expect(parseWikiTags('{{Tag|maxspeed:conditional||40 @ (09:00-18:00)}}')).toEqual([
+      { key: 'maxspeed:conditional', value: '40 @ (09:00-18:00)' },
+    ])
+    expect(parseWikiTags('maxspeed:conditional=||40 @ (09:00-18:00)')).toEqual([
+      { key: 'maxspeed:conditional', value: '40 @ (09:00-18:00)' },
+    ])
+  })
+
+  test('parses multiple tags separated by plus', () => {
+    expect(parseWikiTags('maxspeed:hgv=40 + maxspeed:bus=40')).toEqual([
+      { key: 'maxspeed:hgv', value: '40' },
+      { key: 'maxspeed:bus', value: '40' },
+    ])
+  })
+})
+
+describe('normalizeWikiTagValue', () => {
+  test('removes wiki no-link prefixes', () => {
+    expect(normalizeWikiTagValue('3=yes')).toBe('yes')
+    expect(normalizeWikiTagValue('||designated @ (Mo-Fr 06:00-10:00)')).toBe(
+      'designated @ (Mo-Fr 06:00-10:00)',
+    )
+  })
+})
 
 describe('cleanWikiSignName', () => {
   test('removes Siehe references', () => {

--- a/packages/internal_wiki/src/parseWiki/parseWikiTables.ts
+++ b/packages/internal_wiki/src/parseWiki/parseWikiTables.ts
@@ -57,6 +57,18 @@ const pushWikiTag = (
   }
 }
 
+const stripWikiTagTemplates = (segment: string): string =>
+  segment.replace(/\{\{Tag\|[^}]+\}\}/gi, ' ').trim()
+
+const isInsideParentheses = (text: string, index: number): boolean => {
+  let depth = 0
+  for (let i = 0; i < index; i++) {
+    if (text[i] === '(') depth++
+    else if (text[i] === ')') depth = Math.max(0, depth - 1)
+  }
+  return depth > 0
+}
+
 const parseWikiTagTemplates = (tagsText: string): { key: string; value: string }[] => {
   const tags: { key: string; value: string }[] = []
   const templatePatterns = [
@@ -77,21 +89,22 @@ const parseEqualsFormatWikiTags = (tagsText: string): { key: string; value: stri
   const normalized = tagsText.replace(/\s+/g, ' ')
   const keyPattern = /([a-z0-9:_-]+)\s*=\s*/gi
   for (const segment of normalized.split(/\s*\+\s*/)) {
-    const trimmed = segment.trim()
-    if (!trimmed || trimmed.includes('{{Tag|')) continue
-    const matches = [...trimmed.matchAll(keyPattern)]
+    const plainText = stripWikiTagTemplates(segment.trim())
+    if (!plainText) continue
+    const matches = [...plainText.matchAll(keyPattern)].filter(
+      (match) => !isInsideParentheses(plainText, match.index!),
+    )
     for (let index = 0; index < matches.length; index++) {
       const match = matches[index]!
       const key = match[1]!.trim()
       if (!/^[a-z0-9:_-]+$/i.test(key) || /^\d+$/.test(key)) continue
       const valueStart = match.index! + match[0].length
-      let valueEnd = index + 1 < matches.length ? matches[index + 1]!.index! : trimmed.length
+      let valueEnd = index + 1 < matches.length ? matches[index + 1]!.index! : plainText.length
       if (index + 1 < matches.length && /^\d+$/.test(matches[index + 1]![1]!)) {
-        valueEnd =
-          index + 2 < matches.length ? matches[index + 2]!.index! : trimmed.length
+        valueEnd = index + 2 < matches.length ? matches[index + 2]!.index! : plainText.length
         index += 1
       }
-      pushWikiTag(tags, key, trimmed.slice(valueStart, valueEnd))
+      pushWikiTag(tags, key, plainText.slice(valueStart, valueEnd))
     }
   }
   return tags

--- a/packages/internal_wiki/src/parseWiki/parseWikiTables.ts
+++ b/packages/internal_wiki/src/parseWiki/parseWikiTables.ts
@@ -37,6 +37,56 @@ const parsePolishDescriptionTagCell = (tagsText: string): { key: string; value: 
   return tags
 }
 
+/** OSM wiki {{Tag}} templates use `3=` or `||` before the value to mean "do not link the value". */
+export const normalizeWikiTagValue = (value: string): string => {
+  const trimmed = value.replace(/`/g, '').trim()
+  if (trimmed.startsWith('||')) return trimmed.slice(2).trim()
+  if (trimmed.startsWith('3=')) return trimmed.slice(2).trim()
+  return trimmed
+}
+
+const pushWikiTag = (
+  tags: { key: string; value: string }[],
+  key: string,
+  rawValue: string,
+): void => {
+  const value = normalizeWikiTagValue(rawValue)
+  if (key === 'traffic_sign' || !value || value === '*' || value === '=*') return
+  if (!tags.some((t) => t.key === key && t.value === value)) {
+    tags.push({ key, value })
+  }
+}
+
+const parseWikiTagTemplates = (tagsText: string): { key: string; value: string }[] => {
+  const tags: { key: string; value: string }[] = []
+  const templatePatterns = [
+    /\{\{Tag\|([^|{}]+)\|\|([^}]+)\}\}/gi,
+    /\{\{Tag\|([^|{}]+)\|3=([^}]+)\}\}/gi,
+    /\{\{Tag\|([^|{}]+)\|([^|{}]+)\}\}/gi,
+  ]
+  for (const pattern of templatePatterns) {
+    for (const match of tagsText.matchAll(pattern)) {
+      pushWikiTag(tags, match[1]!.trim(), match[2]!)
+    }
+  }
+  return tags
+}
+
+const parseEqualsFormatWikiTags = (tagsText: string): { key: string; value: string }[] => {
+  const tags: { key: string; value: string }[] = []
+  const normalized = tagsText.replace(/\s+/g, ' ')
+  for (const segment of normalized.split(/\s*\+\s*/)) {
+    const trimmed = segment.trim()
+    if (!trimmed || trimmed.includes('{{Tag|')) continue
+    const eqIndex = trimmed.search(/(?<=[a-z0-9:_-])\s*=/)
+    if (eqIndex === -1) continue
+    const key = trimmed.slice(0, eqIndex).trim()
+    if (!/^[a-z0-9:_-]+$/i.test(key)) continue
+    pushWikiTag(tags, key, trimmed.slice(eqIndex + 1))
+  }
+  return tags
+}
+
 export const parseWikiTags = (tagsText: string): { key: string; value: string }[] => {
   if (!tagsText || /^(n\/a|na|–|-|\*|= \*)$/i.test(tagsText.trim())) return []
 
@@ -46,18 +96,16 @@ export const parseWikiTags = (tagsText: string): { key: string; value: string }[
   }
 
   const tags: { key: string; value: string }[] = []
+  for (const tag of parseWikiTagTemplates(tagsText)) {
+    pushWikiTag(tags, tag.key, tag.value)
+  }
+
   const normalized = tagsText.replace(/\s+/g, ' ')
-  const tagPatterns = [
-    ...normalized.matchAll(/([a-z0-9:_-]+)\s*=\s*([^`\s,;]+(?:\[[^\]]+\])?)/gi),
-    ...normalized.matchAll(/([a-z0-9:_-]+)\s+([a-z0-9:_*-]+)\s*`=`/gi),
-  ]
-  for (const match of tagPatterns) {
-    const key = match[1]!
-    const value = match[2]!.replace(/`/g, '')
-    if (key === 'traffic_sign' || value === '*' || value === '=*') continue
-    if (!tags.some((t) => t.key === key && t.value === value)) {
-      tags.push({ key, value })
-    }
+  for (const tag of parseEqualsFormatWikiTags(normalized)) {
+    pushWikiTag(tags, tag.key, tag.value)
+  }
+  for (const match of normalized.matchAll(/([a-z0-9:_-]+)\s+([a-z0-9:_*-]+)\s*`=`/gi)) {
+    pushWikiTag(tags, match[1]!, match[2]!)
   }
   return tags
 }

--- a/packages/internal_wiki/src/parseWiki/parseWikiTables.ts
+++ b/packages/internal_wiki/src/parseWiki/parseWikiTables.ts
@@ -75,14 +75,24 @@ const parseWikiTagTemplates = (tagsText: string): { key: string; value: string }
 const parseEqualsFormatWikiTags = (tagsText: string): { key: string; value: string }[] => {
   const tags: { key: string; value: string }[] = []
   const normalized = tagsText.replace(/\s+/g, ' ')
+  const keyPattern = /([a-z0-9:_-]+)\s*=\s*/gi
   for (const segment of normalized.split(/\s*\+\s*/)) {
     const trimmed = segment.trim()
     if (!trimmed || trimmed.includes('{{Tag|')) continue
-    const eqIndex = trimmed.search(/(?<=[a-z0-9:_-])\s*=/)
-    if (eqIndex === -1) continue
-    const key = trimmed.slice(0, eqIndex).trim()
-    if (!/^[a-z0-9:_-]+$/i.test(key)) continue
-    pushWikiTag(tags, key, trimmed.slice(eqIndex + 1))
+    const matches = [...trimmed.matchAll(keyPattern)]
+    for (let index = 0; index < matches.length; index++) {
+      const match = matches[index]!
+      const key = match[1]!.trim()
+      if (!/^[a-z0-9:_-]+$/i.test(key) || /^\d+$/.test(key)) continue
+      const valueStart = match.index! + match[0].length
+      let valueEnd = index + 1 < matches.length ? matches[index + 1]!.index! : trimmed.length
+      if (index + 1 < matches.length && /^\d+$/.test(matches[index + 1]![1]!)) {
+        valueEnd =
+          index + 2 < matches.length ? matches[index + 2]!.index! : trimmed.length
+        index += 1
+      }
+      pushWikiTag(tags, key, trimmed.slice(valueStart, valueEnd))
+    }
   }
   return tags
 }

--- a/packages/internal_wiki/src/parseWiki/parseWikiTables.ts
+++ b/packages/internal_wiki/src/parseWiki/parseWikiTables.ts
@@ -45,12 +45,15 @@ export const normalizeWikiTagValue = (value: string): string => {
   return trimmed
 }
 
+const trimWikiTagListSeparator = (value: string): string =>
+  value.replace(/[,;]\s*$/, '').trim()
+
 const pushWikiTag = (
   tags: { key: string; value: string }[],
   key: string,
   rawValue: string,
 ): void => {
-  const value = normalizeWikiTagValue(rawValue)
+  const value = trimWikiTagListSeparator(normalizeWikiTagValue(rawValue))
   if (key === 'traffic_sign' || !value || value === '*' || value === '=*') return
   if (!tags.some((t) => t.key === key && t.value === value)) {
     tags.push({ key, value })

--- a/packages/traffic-sign-converter/src/data-definitions/AU/data/Regulatory.ts
+++ b/packages/traffic-sign-converter/src/data-definitions/AU/data/Regulatory.ts
@@ -505,7 +505,7 @@ export const _Regulatory: SignType[] = [
       {
         geometries: ['way'],
         highwayValues: [],
-        uniqueTags: [{ key: 'red_turn:left', value: '3=yes' }],
+        uniqueTags: [{ key: 'red_turn:left', value: 'yes' }],
       },
     ],
     comments: [],
@@ -565,7 +565,7 @@ export const _Regulatory: SignType[] = [
       {
         geometries: ['way'],
         highwayValues: [],
-        uniqueTags: [{ key: 'red_turn:left', value: '3=yes' }],
+        uniqueTags: [{ key: 'red_turn:left', value: 'yes' }],
       },
     ],
     comments: [],
@@ -1906,7 +1906,7 @@ export const _Regulatory: SignType[] = [
         uniqueTags: [
           {
             key: 'maxspeed:conditional',
-            value: '3=40 @ (Mo-Fr 08:00-09:30,14:30-16:00; PH off; SH off)',
+            value: '40 @ (Mo-Fr 08:00-09:30,14:30-16:00; PH off; SH off)',
           },
           { key: 'hazard', value: 'school_zone' },
         ],
@@ -1941,7 +1941,7 @@ export const _Regulatory: SignType[] = [
         uniqueTags: [
           {
             key: 'maxspeed:conditional',
-            value: '3=60 @ (Mo-Fr 08:00-09:30,14:30-16:00; PH off; SH off)',
+            value: '60 @ (Mo-Fr 08:00-09:30,14:30-16:00; PH off; SH off)',
           },
           { key: 'hazard', value: 'school_zone' },
         ],
@@ -1976,7 +1976,7 @@ export const _Regulatory: SignType[] = [
         uniqueTags: [
           {
             key: 'maxspeed:conditional',
-            value: '3=40 @ (Mo-Fr 08:00-09:30,14:30-16:00; PH off; SH off)',
+            value: '40 @ (Mo-Fr 08:00-09:30,14:30-16:00; PH off; SH off)',
           },
           { key: 'hazard', value: 'school_zone' },
         ],
@@ -2011,7 +2011,7 @@ export const _Regulatory: SignType[] = [
         uniqueTags: [
           {
             key: 'maxspeed:conditional',
-            value: '3=60 @ (Mo-Fr 08:00-09:30,14:30-16:00; PH off; SH off)',
+            value: '60 @ (Mo-Fr 08:00-09:30,14:30-16:00; PH off; SH off)',
           },
           { key: 'hazard', value: 'school_zone' },
         ],
@@ -2080,7 +2080,7 @@ export const _Regulatory: SignType[] = [
         geometries: ['way'],
         highwayValues: [],
         uniqueTags: [
-          { key: 'maxspeed:conditional', value: '3=40 @ (Mo-Fr 09:00-19:00; Sa 09:00-15:00)' },
+          { key: 'maxspeed:conditional', value: '40 @ (Mo-Fr 09:00-19:00; Sa 09:00-15:00)' },
         ],
       },
     ],
@@ -2286,8 +2286,8 @@ export const _Regulatory: SignType[] = [
         geometries: ['way'],
         highwayValues: [],
         uniqueTags: [
-          { key: 'maxspeed:hgv', value: '3=40' },
-          { key: 'maxspeed:bus', value: '3=40' },
+          { key: 'maxspeed:hgv', value: '40' },
+          { key: 'maxspeed:bus', value: '40' },
         ],
       },
     ],
@@ -2315,7 +2315,7 @@ export const _Regulatory: SignType[] = [
         uniqueTags: [
           {
             key: 'maxspeed:conditional',
-            value: '3=40 @ (Mo-Fr 08:00-09:30,14:30-16:00; PH off; SH off)',
+            value: '40 @ (Mo-Fr 08:00-09:30,14:30-16:00; PH off; SH off)',
           },
           { key: 'hazard', value: 'school_zone' },
         ],
@@ -2345,7 +2345,7 @@ export const _Regulatory: SignType[] = [
         uniqueTags: [
           {
             key: 'maxspeed:conditional',
-            value: '3=40 @ (Mo-Fr 08:00-09:30,14:30-16:00; PH off; SH off)',
+            value: '40 @ (Mo-Fr 08:00-09:30,14:30-16:00; PH off; SH off)',
           },
           { key: 'hazard', value: 'school_zone' },
         ],
@@ -2395,7 +2395,7 @@ export const _Regulatory: SignType[] = [
         uniqueTags: [
           {
             key: 'maxspeed:conditional',
-            value: '3=40 @ (Mo-Fr XX:XX-XX:XX,XX:XX-XX:XX; PH off; SH off)',
+            value: '40 @ (Mo-Fr XX:XX-XX:XX,XX:XX-XX:XX; PH off; SH off)',
           },
           { key: 'hazard', value: 'school_zone' },
         ],
@@ -2425,7 +2425,7 @@ export const _Regulatory: SignType[] = [
         uniqueTags: [
           {
             key: 'maxspeed:conditional',
-            value: '3=40 @ (Mo-Fr XX:XX-XX:XX,XX:XX-XX:XX; PH off; SH off)',
+            value: '40 @ (Mo-Fr XX:XX-XX:XX,XX:XX-XX:XX; PH off; SH off)',
           },
           { key: 'hazard', value: 'school_zone' },
         ],
@@ -2528,8 +2528,8 @@ export const _Regulatory: SignType[] = [
         highwayValues: [],
         uniqueTags: [
           { key: 'maxspeed', value: '60' },
-          { key: 'maxspeed:hgv', value: '3=40' },
-          { key: 'maxspeed:bus', value: '3=40' },
+          { key: 'maxspeed:hgv', value: '40' },
+          { key: 'maxspeed:bus', value: '40' },
         ],
       },
     ],
@@ -2557,7 +2557,7 @@ export const _Regulatory: SignType[] = [
         uniqueTags: [
           {
             key: 'maxspeed:conditional',
-            value: '3=40 @ (Mo-Fr 08:00-09:00,14:30-15:30; PH off; SH off)',
+            value: '40 @ (Mo-Fr 08:00-09:00,14:30-15:30; PH off; SH off)',
           },
           { key: 'hazard', value: 'school_zone' },
         ],
@@ -2605,7 +2605,7 @@ export const _Regulatory: SignType[] = [
         uniqueTags: [
           {
             key: 'maxspeed:conditional',
-            value: '3=40 @ (Mo-Fr 08:00-09:00,14:30-15:30; PH off; SH off)',
+            value: '40 @ (Mo-Fr 08:00-09:00,14:30-15:30; PH off; SH off)',
           },
           { key: 'hazard', value: 'school_zone' },
         ],
@@ -2632,7 +2632,7 @@ export const _Regulatory: SignType[] = [
       {
         geometries: ['way'],
         highwayValues: [],
-        uniqueTags: [{ key: 'maxspeed:roadtrain', value: '3=40' }],
+        uniqueTags: [{ key: 'maxspeed:roadtrain', value: '40' }],
       },
     ],
     comments: [],
@@ -2692,7 +2692,7 @@ export const _Regulatory: SignType[] = [
       {
         geometries: ['way'],
         highwayValues: [],
-        uniqueTags: [{ key: 'maxstay:conditional', value: '3=1 hour @ (Sa 09:00-12:00)' }],
+        uniqueTags: [{ key: 'maxstay:conditional', value: '1 hour @ (Sa 09:00-12:00)' }],
       },
     ],
     comments: [],
@@ -2718,7 +2718,7 @@ export const _Regulatory: SignType[] = [
         geometries: ['way'],
         highwayValues: [],
         uniqueTags: [
-          { key: 'maxstay:conditional', value: '3=2 hours @ (Mo-Fr 09:00-16:00; Sa 09:00-12:00)' },
+          { key: 'maxstay:conditional', value: '2 hours @ (Mo-Fr 09:00-16:00; Sa 09:00-12:00)' },
         ],
       },
     ],
@@ -2762,7 +2762,7 @@ export const _Regulatory: SignType[] = [
       {
         geometries: ['way'],
         highwayValues: [],
-        uniqueTags: [{ key: 'maxstay:conditional', value: '3=2 minutes @ (Mo-Fr 09:00-16:00)' }],
+        uniqueTags: [{ key: 'maxstay:conditional', value: '2 minutes @ (Mo-Fr 09:00-16:00)' }],
       },
     ],
     comments: [],
@@ -2786,7 +2786,7 @@ export const _Regulatory: SignType[] = [
       {
         geometries: ['way'],
         highwayValues: [],
-        uniqueTags: [{ key: 'maxstay:conditional', value: '3=5 minutes @ (Mo-Fr 09:00-16:00)' }],
+        uniqueTags: [{ key: 'maxstay:conditional', value: '5 minutes @ (Mo-Fr 09:00-16:00)' }],
       },
     ],
     comments: [],
@@ -2810,7 +2810,7 @@ export const _Regulatory: SignType[] = [
       {
         geometries: ['way'],
         highwayValues: [],
-        uniqueTags: [{ key: 'maxstay:conditional', value: '3=10 minutes @ (Mo-Fr 09:00-16:00)' }],
+        uniqueTags: [{ key: 'maxstay:conditional', value: '10 minutes @ (Mo-Fr 09:00-16:00)' }],
       },
     ],
     comments: [],
@@ -2837,7 +2837,7 @@ export const _Regulatory: SignType[] = [
         uniqueTags: [
           {
             key: 'maxstay:conditional',
-            value: '3=15 minutes @ (Mo-Fr 09:00-16:00; Sa 09:00-12:00)',
+            value: '15 minutes @ (Mo-Fr 09:00-16:00; Sa 09:00-12:00)',
           },
         ],
       },
@@ -2866,7 +2866,7 @@ export const _Regulatory: SignType[] = [
         uniqueTags: [
           {
             key: 'maxstay:conditional',
-            value: '3=30 minutes @ (Mo-Fr 09:00-16:00; Sa 09:00-12:00)',
+            value: '30 minutes @ (Mo-Fr 09:00-16:00; Sa 09:00-12:00)',
           },
         ],
       },
@@ -2895,7 +2895,7 @@ export const _Regulatory: SignType[] = [
         uniqueTags: [
           {
             key: 'maxstay:conditional',
-            value: '3=90 minutes @ (Mo-Fr 09:00-16:00; Sa 09:00-12:00)',
+            value: '90 minutes @ (Mo-Fr 09:00-16:00; Sa 09:00-12:00)',
           },
         ],
       },
@@ -3347,7 +3347,7 @@ export const _Regulatory: SignType[] = [
     description: null,
     kind: 'traffic_sign',
     tagRecommendationsByGeometry: [
-      { geometries: ['way'], highwayValues: [], uniqueTags: [{ key: 'shoulder', value: '3=yes' }] },
+      { geometries: ['way'], highwayValues: [], uniqueTags: [{ key: 'shoulder', value: 'yes' }] },
     ],
     comments: [],
     catalogue: {
@@ -3372,7 +3372,7 @@ export const _Regulatory: SignType[] = [
         highwayValues: [],
         uniqueTags: [
           { key: 'amenity', value: 'parking' },
-          { key: 'maxstay:conditional', value: '3=2 hours @ (Mo-Fr 08:30-17:00, Sa 08:30-12:00)' },
+          { key: 'maxstay:conditional', value: '2 hours @ (Mo-Fr 08:30-17:00, Sa 08:30-12:00)' },
         ],
       },
     ],
@@ -3398,7 +3398,7 @@ export const _Regulatory: SignType[] = [
         geometries: ['way'],
         highwayValues: [],
         uniqueTags: [
-          { key: 'maxstay:conditional', value: '3=2 hours @ (Mo-Fr 08:30-17:00, Sa 08:30-12:00)' },
+          { key: 'maxstay:conditional', value: '2 hours @ (Mo-Fr 08:30-17:00, Sa 08:30-12:00)' },
         ],
       },
     ],
@@ -4083,7 +4083,7 @@ export const _Regulatory: SignType[] = [
         highwayValues: [],
         uniqueTags: [
           { key: 'bridge', value: 'yes' },
-          { key: 'maxweight:conditional', value: '3=X @ (axles=1); X @ (axles=2); X @ (axles=3)' },
+          { key: 'maxweight:conditional', value: 'X @ (axles=1); X @ (axles=2); X @ (axles=3)' },
         ],
       },
     ],
@@ -4510,8 +4510,8 @@ export const _Regulatory: SignType[] = [
         geometries: ['way'],
         highwayValues: [],
         uniqueTags: [
-          { key: 'lanes:both_ways', value: '3=1' },
-          { key: 'turn:lanes:both_ways', value: '3=right' },
+          { key: 'lanes:both_ways', value: '1' },
+          { key: 'turn:lanes:both_ways', value: 'right' },
         ],
       },
     ],
@@ -4913,7 +4913,7 @@ export const _Regulatory: SignType[] = [
         geometries: ['way'],
         highwayValues: [],
         uniqueTags: [
-          { key: 'hov', value: '3=designated @ (Mo-Fr 06:00-10:00)' },
+          { key: 'hov', value: 'designated @ (Mo-Fr 06:00-10:00)' },
           { key: 'hov:minimum', value: '2' },
         ],
       },
@@ -4940,7 +4940,7 @@ export const _Regulatory: SignType[] = [
         geometries: ['way'],
         highwayValues: [],
         uniqueTags: [
-          { key: 'hov', value: '3=designated @ (Mo-Fr 06:30-10:00,15:30-19:00)' },
+          { key: 'hov', value: 'designated @ (Mo-Fr 06:30-10:00,15:30-19:00)' },
           { key: 'hov:minimum', value: '2' },
         ],
       },
@@ -4967,7 +4967,7 @@ export const _Regulatory: SignType[] = [
         geometries: ['way'],
         highwayValues: [],
         uniqueTags: [
-          { key: 'hov', value: '3=designated @ (Mo-Fr 06:00-10:00)' },
+          { key: 'hov', value: 'designated @ (Mo-Fr 06:00-10:00)' },
           { key: 'hov:minimum', value: '3' },
         ],
       },
@@ -4994,7 +4994,7 @@ export const _Regulatory: SignType[] = [
         geometries: ['way'],
         highwayValues: [],
         uniqueTags: [
-          { key: 'hov', value: '3=designated @ (Mo-Fr 06:30-10:00,15:30-19:00)' },
+          { key: 'hov', value: 'designated @ (Mo-Fr 06:30-10:00,15:30-19:00)' },
           { key: 'hov:minimum', value: '3' },
         ],
       },
@@ -5402,7 +5402,7 @@ export const _Regulatory: SignType[] = [
     description: null,
     kind: 'traffic_sign',
     tagRecommendationsByGeometry: [
-      { geometries: ['way'], highwayValues: [], uniqueTags: [{ key: 'except', value: '3=bus' }] },
+      { geometries: ['way'], highwayValues: [], uniqueTags: [{ key: 'except', value: 'bus' }] },
     ],
     comments: [],
     catalogue: {
@@ -5425,7 +5425,7 @@ export const _Regulatory: SignType[] = [
       {
         geometries: ['way'],
         highwayValues: [],
-        uniqueTags: [{ key: 'except', value: '3=bicycle' }],
+        uniqueTags: [{ key: 'except', value: 'bicycle' }],
       },
     ],
     comments: [],
@@ -5449,7 +5449,7 @@ export const _Regulatory: SignType[] = [
       {
         geometries: ['way'],
         highwayValues: [],
-        uniqueTags: [{ key: 'except', value: '3=private' }],
+        uniqueTags: [{ key: 'except', value: 'private' }],
       },
     ],
     comments: [],
@@ -5565,7 +5565,7 @@ export const _Regulatory: SignType[] = [
     description: null,
     kind: 'traffic_sign',
     tagRecommendationsByGeometry: [
-      { geometries: ['way'], highwayValues: [], uniqueTags: [{ key: 'lanes', value: '3=1' }] },
+      { geometries: ['way'], highwayValues: [], uniqueTags: [{ key: 'lanes', value: '1' }] },
     ],
     comments: [],
     catalogue: {
@@ -5585,7 +5585,7 @@ export const _Regulatory: SignType[] = [
     description: null,
     kind: 'traffic_sign',
     tagRecommendationsByGeometry: [
-      { geometries: ['way'], highwayValues: [], uniqueTags: [{ key: 'narrow', value: '3=yes' }] },
+      { geometries: ['way'], highwayValues: [], uniqueTags: [{ key: 'narrow', value: 'yes' }] },
     ],
     comments: [],
     catalogue: {
@@ -5656,7 +5656,7 @@ export const _Regulatory: SignType[] = [
       {
         geometries: ['way'],
         highwayValues: [],
-        uniqueTags: [{ key: 'except', value: '3=bus,taxi' }],
+        uniqueTags: [{ key: 'except', value: 'bus,taxi' }],
       },
     ],
     comments: [],
@@ -5677,7 +5677,7 @@ export const _Regulatory: SignType[] = [
     description: null,
     kind: 'traffic_sign',
     tagRecommendationsByGeometry: [
-      { geometries: ['way'], highwayValues: [], uniqueTags: [{ key: 'except', value: '3=tram' }] },
+      { geometries: ['way'], highwayValues: [], uniqueTags: [{ key: 'except', value: 'tram' }] },
     ],
     comments: [],
     catalogue: {
@@ -5700,7 +5700,7 @@ export const _Regulatory: SignType[] = [
       {
         geometries: ['way'],
         highwayValues: [],
-        uniqueTags: [{ key: 'except', value: '3=bus,taxi' }],
+        uniqueTags: [{ key: 'except', value: 'bus,taxi' }],
       },
     ],
     comments: [],
@@ -5721,7 +5721,7 @@ export const _Regulatory: SignType[] = [
     description: null,
     kind: 'traffic_sign',
     tagRecommendationsByGeometry: [
-      { geometries: ['way'], highwayValues: [], uniqueTags: [{ key: 'except', value: '3=hgv' }] },
+      { geometries: ['way'], highwayValues: [], uniqueTags: [{ key: 'except', value: 'hgv' }] },
     ],
     comments: [],
     catalogue: {
@@ -5744,7 +5744,7 @@ export const _Regulatory: SignType[] = [
       {
         geometries: ['way'],
         highwayValues: [],
-        uniqueTags: [{ key: 'except', value: '3=emergency' }],
+        uniqueTags: [{ key: 'except', value: 'emergency' }],
       },
     ],
     comments: [],

--- a/packages/traffic-sign-converter/src/data-definitions/AU/data/Warning.ts
+++ b/packages/traffic-sign-converter/src/data-definitions/AU/data/Warning.ts
@@ -3427,7 +3427,7 @@ export const _Warning: SignType[] = [
       {
         geometries: ['way'],
         highwayValues: [],
-        uniqueTags: [{ key: 'maxspeed:advisory', value: '3=20' }],
+        uniqueTags: [{ key: 'maxspeed:advisory', value: '20' }],
       },
     ],
     comments: [],
@@ -6759,7 +6759,7 @@ export const _Warning: SignType[] = [
       {
         geometries: ['way'],
         highwayValues: [],
-        uniqueTags: [{ key: 'maxspeed:advisory', value: '3=45' }],
+        uniqueTags: [{ key: 'maxspeed:advisory', value: '45' }],
       },
     ],
     comments: [],
@@ -6783,7 +6783,7 @@ export const _Warning: SignType[] = [
       {
         geometries: ['way'],
         highwayValues: [],
-        uniqueTags: [{ key: 'maxspeed:advisory', value: '3=45' }],
+        uniqueTags: [{ key: 'maxspeed:advisory', value: '45' }],
       },
     ],
     comments: [],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes incorrect tag recommendations for signs like AU:R5-1 where wiki `{{Tag}}` templates use `3=` (or `||`) to mean "do not link the value".

**Before:** `maxstay:conditional=3=1 hour @ (Sa 09:00-12:00)`  
**After:** `maxstay:conditional=1 hour @ (Sa 09:00-12:00)`

## Bugbot findings — all resolved

### 1. Space-separated tags no longer parsed
Fixed in 03e15a2. Parser extracts all `key=value` pairs per segment.

Wiki tests: FR:A1a (`traffic_sign=FR:A1a hazard=turn`), AU R4-246, AU R5-20, `parseUniversalTable` FR A1a integration.

### 2. Equals inside conditionals split
Fixed in 03e15a2. Equals inside `(...)` are ignored when splitting values.

Wiki tests: AU R6-17 (`axles=1` in conditional), FR SC1b (`weightrating > 5.5`), AU R9-1-1.

### 3. Plain tags skipped with templates
Fixed in 03e15a2. `{{Tag|...}}` templates stripped before parsing plain text in same segment.

Wiki tests: AU R4-V105, AU W5-V129, mixed `{{Tag|bridge|yes}} maxspeed=10`.

### 4. Comma-separated tags misparsed
Fixed in latest commit. Trailing `,` / `;` list separators trimmed from parsed values.

Wiki tests: DE 1024-17 combination text (`motor_vehicle=no, agricultural=yes`), `vehicle=no, agricultural=yes`, `hazard=curve; hazard=turn`.

## Changes

- **`parseWikiTags`** handles `3=`/`||` prefixes, multi-word conditionals, space/comma/semicolon-separated tags, parenthesised equals, and mixed template/plain segments
- Added `normalizeWikiTagValue` helper and 71 unit/integration tests from real OSM wiki cell text
- Mirrored parsing logic in `script-import-wiki-catalogue.ts`
- Corrected 49 AU catalogue entries in `Regulatory.ts` and `Warning.ts`

## Test plan

- [x] `packages/internal_wiki` tests pass (71 tests)
- [x] `packages/traffic-sign-converter` tests pass (265 tests)
- [x] Wiki-derived test cases audited against live AU/FR/AT/DE wiki HTML

Fixes https://trafficsigns.osm-verkehrswende.org/AU?signs=AU:R5-1
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2decfbdd-2db8-44e2-a19f-48ff879866d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2decfbdd-2db8-44e2-a19f-48ff879866d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

