### PR TITLE
fix(DE:298): remove colour question, add comment for special cases

### DIFF
--- a/packages/traffic-sign-converter/src/data-definitions/DE/data/surface.ts
+++ b/packages/traffic-sign-converter/src/data-definitions/DE/data/surface.ts
@@ -23,7 +23,7 @@ export const _surface: SignType[] = [
       {
         lang: 'de',
         comment:
-          'Die Markierung ist in der Regel weiß. Bei Sonderfällen kann optional `colour=*` gesetzt werden (z. B. gelbe Baustellenmarkierungen oder lila Markierungen auf Privatgrund). Siehe [DE:Key:road_marking](https://wiki.openstreetmap.org/wiki/DE:Key:road_marking#Weitere_zus%C3%A4tzliche_Attribute_zur_physischen_Beschreibung_von_Markierungen).',
+          'Die Markierung ist in der Regel weiß. Bei Sonderfällen kann optional `colour=*` gesetzt werden. Siehe [DE:Key:road_marking](https://wiki.openstreetmap.org/wiki/DE:Key:road_marking#Weitere_zus%C3%A4tzliche_Attribute_zur_physischen_Beschreibung_von_Markierungen).',
       },
     ],
     compatibility: { canReceiveModifiers: false },

--- a/packages/traffic-sign-converter/src/data-definitions/DE/data/surface.ts
+++ b/packages/traffic-sign-converter/src/data-definitions/DE/data/surface.ts
@@ -23,7 +23,7 @@ export const _surface: SignType[] = [
       {
         lang: 'de',
         comment:
-          'Die Markierung ist in der Regel weiß. Bei Sonderfällen kann optional `colour=*` gesetzt werden (z. B. gelbe Baustellenmarkierungen oder lila Markierungen auf Privatgrund). Siehe [DE:Key:road_marking](https://wiki.openstreetmap.org/wiki/DE:Key:road_marking#Weitere_Attribute).',
+          'Die Markierung ist in der Regel weiß. Bei Sonderfällen kann optional `colour=*` gesetzt werden (z. B. gelbe Baustellenmarkierungen oder lila Markierungen auf Privatgrund). Siehe [DE:Key:road_marking](https://wiki.openstreetmap.org/wiki/DE:Key:road_marking#Weitere_zus%C3%A4tzliche_Attribute_zur_physischen_Beschreibung_von_Markierungen).',
       },
     ],
     compatibility: { canReceiveModifiers: false },

--- a/packages/traffic-sign-converter/src/data-definitions/DE/data/surface.ts
+++ b/packages/traffic-sign-converter/src/data-definitions/DE/data/surface.ts
@@ -19,8 +19,13 @@ export const _surface: SignType[] = [
         ],
       },
     ],
-    questions: [markingColorQuestion()],
-    comments: [],
+    comments: [
+      {
+        lang: 'de',
+        comment:
+          'Die Markierung ist in der Regel weiß. Bei Sonderfällen kann optional `colour=*` gesetzt werden (z. B. gelbe Baustellenmarkierungen oder lila Markierungen auf Privatgrund). Siehe [DE:Key:road_marking](https://wiki.openstreetmap.org/wiki/DE:Key:road_marking#Weitere_Attribute).',
+      },
+    ],
     compatibility: { canReceiveModifiers: false },
     catalogue: {
       signCategory: 'surface_sign',

--- a/packages/traffic-sign-converter/src/signsToTags/signsToTags.questions.test.ts
+++ b/packages/traffic-sign-converter/src/signsToTags/signsToTags.questions.test.ts
@@ -94,18 +94,6 @@ describe('question answers in signsToTags()', () => {
     expect(cyclewayTags.has('bicycle')).toBe(false)
   })
 
-  test('markingColor white emits colour tag for DE:298', () => {
-    const signs = signsStateByDescriptiveName('DE', data, ['Sperrflächen'])
-    expect(signs.length).toBeGreaterThan(0)
-    const signKey = signs[0]!.osmValuePart
-    const result = signsToTags(signs, 'DE', 'way', {
-      [signKey]: { markingColor: 'white' },
-    })
-    expect(result.get('colour')).toBe('white')
-    expect(result.get('road_marking')).toBe('restriction')
-    expect(result.get('pattern')).toBe('stripes')
-  })
-
   test('markingColor yellow emits colour tag for DE:299', () => {
     const signs = signsStateByDescriptiveName('DE', data, [
       'Grenzmarkierung für Halt- und Parkverbote',
@@ -120,11 +108,8 @@ describe('question answers in signsToTags()', () => {
     expect(result.get('pattern')).toBe('zigzag')
   })
 
-  test('markingColor nil omits colour tag for DE:298 and DE:299', () => {
-    for (const descriptiveName of [
-      'Sperrflächen',
-      'Grenzmarkierung für Halt- und Parkverbote',
-    ] as const) {
+  test('markingColor nil omits colour tag for DE:299', () => {
+    for (const descriptiveName of ['Grenzmarkierung für Halt- und Parkverbote'] as const) {
       const signs = signsStateByDescriptiveName('DE', data, [descriptiveName])
       expect(signs.length).toBeGreaterThan(0)
       const signKey = signs[0]!.osmValuePart


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**[Cursor Agent]**

Follow-up to #117 per review feedback from @tordans.

## Summary

Removes the `markingColor` question from DE:298 (Sperrflächen). White is the default for this marking; asking users to confirm it added no value.

Adds a German comment instead, noting that `colour=*` may be set for special cases (e.g. yellow construction markings or purple markings on private land), with a link to [DE:Key:road_marking](https://wiki.openstreetmap.org/wiki/DE:Key:road_marking#Weitere_Attribute).

DE:299 keeps the `markingColor` question unchanged.

## Testing

- `bun test signsToTags.questions.test.ts` in `packages/traffic-sign-converter`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d99abe00-ebc4-435d-bc12-a190711e6ac8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d99abe00-ebc4-435d-bc12-a190711e6ac8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

