### PR TITLE
Add osmTags variants for DE:1000-30/31/32/33 with correct oneway tagging

### DIFF
--- a/apps/traffic-sign-tool/messages/de.json
+++ b/apps/traffic-sign-tool/messages/de.json
@@ -307,5 +307,10 @@
   "question_signDirection_prompt": "Ausrichtung",
   "question_signDirection_answer_nil": "Keine Angabe",
   "question_signDirection_answer_forward": "In Fahrtrichtung (Linienrichtung) (direction=forward)",
-  "question_signDirection_answer_backward": "Gegen die Fahrtrichtung (direction=backward)"
+  "question_signDirection_answer_backward": "Gegen die Fahrtrichtung (direction=backward)",
+  "question_centerlineOnewayContext_title": "Mittellinien-Kontext",
+  "question_centerlineOnewayContext_prompt": "Wie ist der Zweirichtungsradverkehr auf der Fahrbahn kartiert?",
+  "question_centerlineOnewayContext_answer_nil": "Keine Angabe",
+  "question_centerlineOnewayContext_answer_adjacentCycleTrack": "Straßenbegleitender Zweirichtungsradweg (cycleway=track, oneway:bicycle=no)",
+  "question_centerlineOnewayContext_answer_contraflowOneWay": "Freigegebene Einbahnstraße (nur oneway:bicycle=no)"
 }

--- a/apps/traffic-sign-tool/messages/en.json
+++ b/apps/traffic-sign-tool/messages/en.json
@@ -307,5 +307,10 @@
   "question_signDirection_prompt": "Orientation",
   "question_signDirection_answer_nil": "Not specified",
   "question_signDirection_answer_forward": "In direction of travel (way direction) (direction=forward)",
-  "question_signDirection_answer_backward": "Against direction of travel (direction=backward)"
+  "question_signDirection_answer_backward": "Against direction of travel (direction=backward)",
+  "question_centerlineOnewayContext_title": "Centerline oneway context",
+  "question_centerlineOnewayContext_prompt": "How is bidirectional cycling mapped on the road centerline?",
+  "question_centerlineOnewayContext_answer_nil": "Not specified",
+  "question_centerlineOnewayContext_answer_adjacentCycleTrack": "Adjacent bidirectional cycle track (cycleway=track, oneway:bicycle=no)",
+  "question_centerlineOnewayContext_answer_contraflowOneWay": "Contraflow cycling on a one-way street (oneway:bicycle=no only)"
 }

--- a/apps/traffic-sign-tool/src/features/i18n/questionLabels.ts
+++ b/apps/traffic-sign-tool/src/features/i18n/questionLabels.ts
@@ -8,6 +8,7 @@ const promptShortLabels: Record<string, () => string> = {
   'guidanceMode.prompt': m.question_guidanceMode_title,
   'highwayClass.prompt': m.question_highwayClass_title,
   'signDirection.prompt': m.question_signDirection_title,
+  'centerlineOnewayContext.prompt': m.question_centerlineOnewayContext_title,
 }
 
 const answerLabels: Record<string, () => string> = {
@@ -33,6 +34,11 @@ const answerLabels: Record<string, () => string> = {
   'signDirection.answer.nil': m.question_signDirection_answer_nil,
   'signDirection.answer.forward': m.question_signDirection_answer_forward,
   'signDirection.answer.backward': m.question_signDirection_answer_backward,
+  'centerlineOnewayContext.answer.nil': m.question_centerlineOnewayContext_answer_nil,
+  'centerlineOnewayContext.answer.adjacentCycleTrack':
+    m.question_centerlineOnewayContext_answer_adjacentCycleTrack,
+  'centerlineOnewayContext.answer.contraflowOneWay':
+    m.question_centerlineOnewayContext_answer_contraflowOneWay,
 }
 
 export const getQuestionPromptShortLabel = (questionI18nKey: string): string =>

--- a/packages/traffic-sign-converter/src/data-definitions/DE/data/conditions__other.ts
+++ b/packages/traffic-sign-converter/src/data-definitions/DE/data/conditions__other.ts
@@ -132,6 +132,12 @@ export const _conditions__other: SignType[] = [
         comment:
           'Zweirichtungsverkehr auf separat kartiertem Weg (`highway=path` oder `highway=cycleway`). Bei Mittellinien-Tagging auf der Fahrbahn gilt `oneway:bicycle=no` statt `oneway=no`.',
       },
+      {
+        tagReference: 'oneway:bicycle=no',
+        lang: 'de',
+        comment:
+          'In Kombination mit Zeichen 240 oder 241 (gemeinsamer bzw. getrennter Geh-/Radweg) ist der Fußverkehr ohnehin bidirektional. Das Zusatzzeichen bezieht sich dann nur auf den Radverkehr; in der Praxis wird teils `oneway:bicycle=no` statt `oneway=no` getaggt. Beide Varianten sind gebräuchlich. Siehe [Wiki](https://wiki.openstreetmap.org/wiki/DE:Verkehrszeichen_in_Deutschland#Zusatzzeichen_1000-32).',
+      },
     ],
     catalogue: {
       signCategory: 'exception_modifier',
@@ -163,6 +169,12 @@ export const _conditions__other: SignType[] = [
         lang: 'de',
         comment:
           'Zweirichtungsverkehr auf separat kartiertem Weg (`highway=path` oder `highway=cycleway`). Bei Mittellinien-Tagging auf der Fahrbahn gilt `oneway:bicycle=no` statt `oneway=no`.',
+      },
+      {
+        tagReference: 'oneway:bicycle=no',
+        lang: 'de',
+        comment:
+          'In Kombination mit Zeichen 240 oder 241 (gemeinsamer bzw. getrennter Geh-/Radweg) ist der Fußverkehr ohnehin bidirektional. Das Zusatzzeichen bezieht sich dann nur auf den Radverkehr; in der Praxis wird teils `oneway:bicycle=no` statt `oneway=no` getaggt. Beide Varianten sind gebräuchlich. Siehe [Wiki](https://wiki.openstreetmap.org/wiki/DE:Verkehrszeichen_in_Deutschland#Zusatzzeichen_1000-32).',
       },
     ],
     catalogue: {

--- a/packages/traffic-sign-converter/src/data-definitions/DE/data/conditions__other.ts
+++ b/packages/traffic-sign-converter/src/data-definitions/DE/data/conditions__other.ts
@@ -1,3 +1,4 @@
+import { centerlineOnewayContextQuestion } from '../../questionCatalog.js'
 import type { SignType } from '../../TrafficSignDataTypes.js'
 
 export const _conditions__other: SignType[] = [
@@ -118,9 +119,20 @@ export const _conditions__other: SignType[] = [
     description: 'zwei gegengerichtete waagerechte Pfeile',
     kind: 'exception_modifier',
     tagRecommendationsByGeometry: [
-      { geometries: ['way'], highwayValues: [], uniqueTags: [{ key: 'oneway', value: 'no' }] },
+      {
+        geometries: ['way'],
+        highwayValues: [],
+        uniqueTags: [{ key: 'oneway', value: 'no' }],
+      },
     ],
-    comments: [],
+    comments: [
+      {
+        tagReference: 'oneway=no',
+        lang: 'de',
+        comment:
+          'Zweirichtungsverkehr auf separat kartiertem Weg (`highway=path` oder `highway=cycleway`). Bei Mittellinien-Tagging auf der Fahrbahn gilt `oneway:bicycle=no` statt `oneway=no`.',
+      },
+    ],
     catalogue: {
       signCategory: 'exception_modifier',
     },
@@ -141,11 +153,18 @@ export const _conditions__other: SignType[] = [
     tagRecommendationsByGeometry: [
       {
         geometries: ['way'],
-        highwayValues: ['path', 'cycleway'],
+        highwayValues: [],
         uniqueTags: [{ key: 'oneway', value: 'no' }],
       },
     ],
-    comments: [],
+    comments: [
+      {
+        tagReference: 'oneway=no',
+        lang: 'de',
+        comment:
+          'Zweirichtungsverkehr auf separat kartiertem Weg (`highway=path` oder `highway=cycleway`). Bei Mittellinien-Tagging auf der Fahrbahn gilt `oneway:bicycle=no` statt `oneway=no`.',
+      },
+    ],
     catalogue: {
       signCategory: 'exception_modifier',
     },
@@ -164,14 +183,39 @@ export const _conditions__other: SignType[] = [
     description: null,
     kind: 'exception_modifier',
     tagRecommendationsByGeometry: [
-      { geometries: ['way'], uniqueTags: [{ key: 'oneway:bicycle', value: 'no' }] },
+      {
+        geometries: ['way'],
+        uniqueTags: [{ key: 'oneway', value: 'no' }],
+        comments: [
+          {
+            lang: 'de',
+            comment:
+              'Separat kartierter Zweirichtungsradweg (`highway=cycleway` o. ä.). Auf dem Weg `oneway=no` verwenden, nicht `oneway:bicycle=no`.',
+          },
+        ],
+      },
+      {
+        geometries: ['way_centerline'],
+        uniqueTags: [
+          { key: 'cycleway', value: 'track' },
+          { key: 'oneway:bicycle', value: 'no' },
+        ],
+        comments: [
+          {
+            lang: 'de',
+            comment:
+              'Straßenbegleitender Radweg als Fahrbahnzusatztag (`cycleway=track` + `oneway:bicycle=no`).',
+          },
+        ],
+      },
     ],
+    questions: [centerlineOnewayContextQuestion()],
     comments: [
       {
         tagReference: null,
         lang: 'de',
         comment:
-          'Bitte [Wiki beachten](https://wiki.openstreetmap.org/wiki/DE:Verkehrszeichen_in_Deutschland#Zusatzzeichen_1000-33), das Tool ist hier nicht vollständig.',
+          'Zunächst vorgesehen mit Zeichen 205 oder 206 vor Zweirichtungsradwegen. Seit 2013 auch unter Zeichen 220 für freigegebene Einbahnstraßen (statt vorher Zeichen 1000-33).',
       },
     ],
     catalogue: {
@@ -193,9 +237,26 @@ export const _conditions__other: SignType[] = [
     kind: 'exception_modifier',
     tagRecommendationsByGeometry: [
       {
-        geometries: ['way'],
-        highwayValues: [],
+        geometries: ['way_centerline'],
         uniqueTags: [{ key: 'oneway:bicycle', value: 'no' }],
+        comments: [
+          {
+            lang: 'de',
+            comment:
+              'Radverkehr in Gegenrichtung auf der Fahrbahn (Einbahnstraße). Seit April 2017 bei freigegebenen Einbahnstraßen stattdessen DE:1000-32 verwenden.',
+          },
+        ],
+      },
+      {
+        geometries: ['way'],
+        uniqueTags: [{ key: 'oneway', value: 'no' }],
+        comments: [
+          {
+            lang: 'de',
+            comment:
+              'Separat kartierter Zweirichtungsradweg: `oneway=no` (nicht `oneway:bicycle=no`). Wird manchmal alternativ zu DE:1000-31 unter Zeichen 240, 237 oder 241 verwendet.',
+          },
+        ],
       },
     ],
     comments: [
@@ -203,7 +264,7 @@ export const _conditions__other: SignType[] = [
         tagReference: null,
         lang: 'de',
         comment:
-          'Bitte [Wiki beachten](https://wiki.openstreetmap.org/wiki/DE:Verkehrszeichen_in_Deutschland#Zusatzzeichen_1000-33), das Tool ist hier nicht vollständig.',
+          'Seit 1. April 2017 bei freigegebenen Einbahnstraßen ungültig; stattdessen DE:1000-32 verwenden.',
       },
     ],
     catalogue: {

--- a/packages/traffic-sign-converter/src/data-definitions/questionCatalog.ts
+++ b/packages/traffic-sign-converter/src/data-definitions/questionCatalog.ts
@@ -156,5 +156,31 @@ export const cycleInfrastructureQuestions = (): SignQuestion[] => [
   surfaceColorQuestion(),
 ]
 
+/**
+ * Centerline oneway tagging for DE:1000-32 — adjacent bidirectional cycle track vs contraflow
+ * cycling on a one-way street (see DE:Verkehrszeichen_in_Deutschland#Zusatzzeichen_1000-32).
+ */
+export const centerlineOnewayContextQuestion = (): SignQuestion => ({
+  questionId: 'centerlineOnewayContext',
+  questionI18nKey: 'centerlineOnewayContext.prompt',
+  geometries: ['way_centerline'],
+  defaultAnswerId: 'adjacentCycleTrack',
+  answers: [
+    nilAnswer('centerlineOnewayContext'),
+    {
+      answerId: 'adjacentCycleTrack',
+      answerI18nKey: 'centerlineOnewayContext.answer.adjacentCycleTrack',
+      geometries: ['way_centerline'],
+    },
+    {
+      answerId: 'contraflowOneWay',
+      answerI18nKey: 'centerlineOnewayContext.answer.contraflowOneWay',
+      geometries: ['way_centerline'],
+      tags: [{ key: 'oneway:bicycle', value: 'no' }],
+      removeTags: [{ key: 'cycleway', value: 'track' }],
+    },
+  ],
+})
+
 /** Node tagging for hazard signs mapped as `traffic_sign` on a way node (see DE:Key:traffic_sign). */
 export const hazardSignNodeQuestions = (): SignQuestion[] => [signDirectionQuestion()]

--- a/packages/traffic-sign-converter/src/index.ts
+++ b/packages/traffic-sign-converter/src/index.ts
@@ -97,6 +97,7 @@ export type {
   ValuePrompt,
 } from './data-definitions/TrafficSignDataTypes.js'
 export {
+  centerlineOnewayContextQuestion,
   cycleInfrastructureQuestions,
   guidanceModeQuestion,
   hazardSignNodeQuestions,

--- a/packages/traffic-sign-converter/src/signsToTags/signsToTags.questions.test.ts
+++ b/packages/traffic-sign-converter/src/signsToTags/signsToTags.questions.test.ts
@@ -212,5 +212,25 @@ describe('question answers in signsToTags()', () => {
       expect(result.get('is_sidepath')).toBe('yes')
       expect(result.get('traffic_sign')).toBe('DE:240,1000-30')
     })
+
+    test('DE:241-30 + DE:1000-31 defaults to oneway=no (oneway:bicycle=no documented in comments)', () => {
+      const mainSign = data.find((item) => item.osmValuePart === '241-30')
+      const modifierSign = data.find((item) => item.osmValuePart === '1000-31')
+      expect(mainSign).toBeDefined()
+      expect(modifierSign).toBeDefined()
+
+      const signs = [
+        transformToSignState('DE', mainSign!),
+        transformToSignState('DE', modifierSign!),
+      ]
+
+      const result = signsToTags(signs, 'DE', 'way', {
+        '241-30': { highwayClass: 'path', sidepath: 'yes' },
+      })
+      expect(result.get('highway')).toMatchObject(['path'])
+      expect(result.get('oneway')).toBe('no')
+      expect(result.has('oneway:bicycle')).toBe(false)
+      expect(result.get('traffic_sign')).toBe('DE:241-30,1000-31')
+    })
   })
 })

--- a/packages/traffic-sign-converter/src/signsToTags/signsToTags.questions.test.ts
+++ b/packages/traffic-sign-converter/src/signsToTags/signsToTags.questions.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'vitest'
 import { countryDefinitions } from '../data-definitions/countryDefinitions.js'
 import { QUESTION_NIL_ANSWER_ID } from '../data-definitions/TrafficSignDataTypes.js'
 import { signsStateByDescriptiveName } from '../utils/signsByDescriptiveName.js'
+import { transformToSignState } from '../utils/transformToSignState.js'
 import { signsToTags } from './signsToTags.js'
 
 describe('question answers in signsToTags()', () => {
@@ -133,5 +134,83 @@ describe('question answers in signsToTags()', () => {
     const wayTags = signsToTags(signs, 'DE', 'way', answers)
     expect(wayTags.has('direction')).toBe(false)
     expect(wayTags.get('hazard')).toBe('cyclists')
+  })
+
+  describe('DE:1000-30/31/32/33 bidirectional oneway tagging', () => {
+    test('DE:1000-31 separate way recommends oneway=no', () => {
+      const sign = data.find((item) => item.osmValuePart === '1000-31')
+      expect(sign).toBeDefined()
+
+      const result = signsToTags([transformToSignState('DE', sign!)], 'DE', 'way')
+      expect(result.get('oneway')).toBe('no')
+      expect(result.has('oneway:bicycle')).toBe(false)
+    })
+
+    test('DE:1000-32 separate way recommends oneway=no', () => {
+      const signs = signsStateByDescriptiveName('DE', data, [
+        'Radverkehr kreuzt von links und rechts',
+      ])
+      expect(signs.length).toBeGreaterThan(0)
+
+      const result = signsToTags(signs, 'DE', 'way')
+      expect(result.get('oneway')).toBe('no')
+      expect(result.has('oneway:bicycle')).toBe(false)
+    })
+
+    test('DE:1000-32 centerline defaults to cycleway=track and oneway:bicycle=no', () => {
+      const signs = signsStateByDescriptiveName('DE', data, [
+        'Radverkehr kreuzt von links und rechts',
+      ])
+      expect(signs.length).toBeGreaterThan(0)
+
+      const result = signsToTags(signs, 'DE', 'way_centerline')
+      expect(result.get('cycleway')).toBe('track')
+      expect(result.get('oneway:bicycle')).toBe('no')
+      expect(result.has('oneway')).toBe(false)
+    })
+
+    test('DE:1000-32 centerline contraflow one-way removes cycleway=track', () => {
+      const signs = signsStateByDescriptiveName('DE', data, [
+        'Radverkehr kreuzt von links und rechts',
+      ])
+      expect(signs.length).toBeGreaterThan(0)
+      const signKey = signs[0]!.osmValuePart
+
+      const result = signsToTags(signs, 'DE', 'way_centerline', {
+        [signKey]: { centerlineOnewayContext: 'contraflowOneWay' },
+      })
+      expect(result.get('oneway:bicycle')).toBe('no')
+      expect(result.has('cycleway')).toBe(false)
+    })
+
+    test('DE:1000-33 centerline recommends oneway:bicycle=no', () => {
+      const signs = signsStateByDescriptiveName('DE', data, ['Radverkehr im Gegenverkehr'])
+      expect(signs.length).toBeGreaterThan(0)
+
+      const centerlineTags = signsToTags(signs, 'DE', 'way_centerline')
+      expect(centerlineTags.get('oneway:bicycle')).toBe('no')
+      expect(centerlineTags.has('oneway')).toBe(false)
+
+      const wayTags = signsToTags(signs, 'DE', 'way')
+      expect(wayTags.get('oneway')).toBe('no')
+      expect(wayTags.has('oneway:bicycle')).toBe(false)
+    })
+
+    test('DE:240 + DE:1000-30 with sidepath keeps oneway=no on separate way', () => {
+      const signs = signsStateByDescriptiveName('DE', data, [
+        'Gemeinsamer Fuß- und Radweg',
+        'Beide Richtungen',
+      ])
+      const modifier = signs.find((item) => item.osmValuePart === '1000-30')
+      expect(modifier).toBeDefined()
+
+      const result = signsToTags(signs, 'DE', 'way', {
+        '240': { sidepath: 'yes' },
+      })
+      expect(result.get('highway')).toMatchObject(['path'])
+      expect(result.get('oneway')).toBe('no')
+      expect(result.get('is_sidepath')).toBe('yes')
+      expect(result.get('traffic_sign')).toBe('DE:240,1000-30')
+    })
   })
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**[Cursor Agent]**

Closes #33

Automated catalogue update for #33.

## Summary

Implements correct OSM tagging recommendations for bidirectional cycling modifiers `DE:1000-30`, `DE:1000-31`, `DE:1000-32`, and `DE:1000-33` based on the wiki input from the submitter.

## Changes

### Separate geometries (`way`)
- `DE:1000-30`, `DE:1000-31`, `DE:1000-32`, and `DE:1000-33` recommend `oneway=no` on separately mapped ways — not `oneway:bicycle=no`.

### Centerline tagging (`way_centerline`)
- **`DE:1000-32`**: recommends `cycleway=track` + `oneway:bicycle=no` for street-adjacent bidirectional cycle tracks; adds a **question** to switch to contraflow one-way street tagging (`oneway:bicycle=no` only).
- **`DE:1000-33`**: recommends `oneway:bicycle=no` on the road centerline; separate-way alternative documented in geometry-specific comments.

### `DE:1000-30` / `DE:1000-31` with Zeichen 240 / 241
- Cannot automatically switch to `oneway:bicycle=no` when combined with shared/segregated foot/cycle paths (foot is already bidirectional; modifier only affects cycling).
- Added sign comments documenting that **`oneway:bicycle=no` is also in use** alongside the default `oneway=no`, with a link to the [OSM wiki](https://wiki.openstreetmap.org/wiki/DE:Verkehrszeichen_in_Deutschland#Zusatzzeichen_1000-32).

### Questions
- New `centerlineOnewayContext` question (DE/EN i18n) on `DE:1000-32`.

## Testing
- Converter tests cover separate-way vs. centerline output, `DE:240 + DE:1000-30`, and `DE:241-30 + DE:1000-31` combinations.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0c0e92e8-e5fd-4ceb-87a4-5bb7ee66a290"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0c0e92e8-e5fd-4ceb-87a4-5bb7ee66a290"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

